### PR TITLE
Add possibility to create a service using the device resource

### DIFF
--- a/logicmonitor/helper_function_test.go
+++ b/logicmonitor/helper_function_test.go
@@ -1,0 +1,47 @@
+package logicmonitor
+
+import (
+	"testing"
+)
+
+func TestGetDeviceTypeID(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceType string
+		expected   int32
+	}{
+		{"host", "host", 0},
+		{"hostcaps", "HOST", 0},
+		{"service", "service", 6},
+		{"servicecaps", "SERVICE", 6},
+		{"defaulttozero", "default", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getDeviceTypeID(tc.deviceType)
+			if actual != tc.expected {
+				t.Fatalf("expected: %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetDeviceType(t *testing.T) {
+	cases := []struct {
+		name         string
+		deviceTypeID int32
+		expected     string
+	}{
+		{"host", 0, "host"},
+		{"service", 6, "service"},
+		{"defaulttohost", 1, "host"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getDeviceType(tc.deviceTypeID)
+			if actual != tc.expected {
+				t.Fatalf("expected: %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/logicmonitor/helper_functions.go
+++ b/logicmonitor/helper_functions.go
@@ -61,6 +61,24 @@ func getCollectorFilters(d *schema.ResourceData) (t string) {
 	return
 }
 
+// Get device type id from string
+func getDeviceTypeID(t string) int32 {
+	var deviceTypeID int32 = 0
+	if strings.ToLower(t) == "service" {
+		deviceTypeID = 6
+	}
+	return deviceTypeID
+}
+
+// Get device type from id
+func getDeviceType(i int32) string {
+	var deviceType = "host"
+	if i == 6 {
+		deviceType = "service"
+	}
+	return deviceType
+}
+
 // add widget token helper function
 func getWidgetTokens(d *schema.ResourceData) (t []*models.WidgetToken) {
 	// interate through hashmap to get custom/system properties
@@ -113,6 +131,10 @@ func makeDeviceObject(d *schema.ResourceData) (output models.Device) {
 	var hostgroupID = d.Get("hostgroup_id").(string)
 	var name = d.Get("ip_addr").(string)
 
+	// Device type will default to HOST (0) and optionally be set to SERVICE (6)
+	var deviceType = d.Get("type").(string)
+	var deviceTypeID int32 = getDeviceTypeID(deviceType)
+
 	// if displayname is not there, we can automatically add ipaddr
 	var displayname = d.Get("display_name").(string)
 	if displayname == "" {
@@ -121,6 +143,7 @@ func makeDeviceObject(d *schema.ResourceData) (output models.Device) {
 
 	output = models.Device{
 		Name:                 &name,
+		DeviceType:           deviceTypeID,
 		DisplayName:          &displayname,
 		DisableAlerting:      d.Get("disable_alerting").(bool),
 		HostGroupIds:         &hostgroupID,


### PR DESCRIPTION
Goal is to be able to set up services used by dashboards in different environments in an automated fashion.

The type attribute on a device will default to host. If a service is added the user also needs to provide the two custom
properties predef.bizservice.members and predef.bizservice.evalMembersInterval which are required by the API.

You will need to set the collector id to -4 as of now. Limitation from the API.

Tested with:
```
provider "logicmonitor" {}

resource "logicmonitor_device" "newhost" {
  ip_addr = "newhost"
  collector = "<id>"
  type = "host"
}

resource "logicmonitor_device" "oldhost" {
  ip_addr = "oldhost"
  collector = "<id>"
}

resource "logicmonitor_device" "service" {
  ip_addr = "testservice"
  collector = "-4"
  type = "service"
  properties = {
    "predef.bizservice.members" = "{\"device\":[{\"deviceGroupFullPath\":\"Testgroup*\",\"deviceDisplayName\":\"Testname*\",\"deviceProperties\":[]}],\"instance\":[]}"
    "predef.bizservice.evalMembersInterval" = "5"
  }
}
```

Plan for service
```
Terraform will perform the following actions:

  # logicmonitor_device.service will be created
  + resource "logicmonitor_device" "service" {
      + collector        = -4
      + disable_alerting = true
      + id               = (known after apply)
      + ip_addr          = "testservice"
      + properties       = {
          + "predef.bizservice.evalMembersInterval" = "5"
          + "predef.bizservice.members"             = jsonencode(
                {
                  + device   = [
                      + {
                          + deviceDisplayName   = "Testname*"
                          + deviceGroupFullPath = "Testgroup*"
                          + deviceProperties    = []
                        },
                    ]
                  + instance = []
                }
            )
        }
      + type             = "service"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Importing a service by ID will set the type correctly but not with name since it is not included in the API response.