### PR TITLE
Domain field added to handle gov domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ provider "logicmonitor" {
   api_id = var.logicmonitor_api_id
   api_key = var.logicmonitor_api_key
   company = var.logicmonitor_company
+  domain = logicmonitor.com
+  "The company domain(optional). Defaults to logicmonitor.com. For gov companies, specify the appropriate domain value (e.g., qa-lmgov.us)"
   bulk_resource = true/false
   "When working with bulk resources, this feature is optional to handle the API's rate limit"
 }

--- a/logicmonitor/provider.go
+++ b/logicmonitor/provider.go
@@ -22,6 +22,11 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LM_API_KEY", nil),
 			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "logicmonitor.com",
+			},
 			"company": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -31,7 +36,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "(Experimental) true if going for bulk resource, default is false",
+				Description: "true if going for bulk resource, default is false",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -71,8 +76,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	id := d.Get("api_id").(string)
 	key := d.Get("api_key").(string)
-	company := d.Get("company").(string) + ".logicmonitor.com"
+	domain := d.Get("domain").(string)
+	company := d.Get("company").(string) + "." + domain
 	bulkResource := d.Get("bulk_resource").(bool)
+
 	config := client.NewConfig()
 	config.SetAccessKey(&key)
 	config.SetAccessID(&id)

--- a/website/docs/index.markdown
+++ b/website/docs/index.markdown
@@ -360,3 +360,4 @@ The following arguments are supported:
 * `api_key` - (Required) LogicMonitor API key. This can also be set via the `LM_API_KEY` environment variable.
 * `company` - (Required) LogicMonitor company name. This can also be set via the `LM_COMPANY` environment variable.
 * `bulk_resource` - (Optional) True if going for bulk resources that can exceed the rate limit. The default value is false.
+* `domain` - The company domain. Defaults to logicmonitor.com. For gov companies, specify the appropriate domain value (e.g., qa-lmgov.us).


### PR DESCRIPTION
Domain(optional) field added to handle gov domains . Default is logicmonitor.com. For gov companies provide specific domain.