### PR TITLE
need_stc_group_and_sorted_cp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.21 (May, 2025)
+
+* Domain field added in provider block to handle gov domains
+* Special handling for 'need_stc_grp_and_sorted_c_p' query param
+
+
+## 2.0.20 (April 11, 2025)
+
+* HostGroupIds and custom properties fix
+
 ## 2.0.19 (December 23, 2024)
 
 * Updated implementation of Alert rule for allowing escalation interval of 0 

--- a/logicmonitor/schemata/device_schema.go
+++ b/logicmonitor/schemata/device_schema.go
@@ -483,7 +483,12 @@ func SetDeviceResourceData(d *schema.ResourceData, m *models.Device) {
 	d.Set("last_rawdata_time", m.LastRawdataTime)
 	d.Set("link", m.Link)
 	d.Set("name", m.Name)
-	d.Set("need_stc_grp_and_sorted_c_p", m.NeedStcGrpAndSortedCP)
+	// Special handling for 'need_stc_grp_and_sorted_c_p' as it is a query param and not returned by API
+	if val, ok := d.GetOk("need_stc_grp_and_sorted_c_p"); ok {
+		d.Set("need_stc_grp_and_sorted_c_p", val)
+	} else {
+		d.Set("need_stc_grp_and_sorted_c_p", m.NeedStcGrpAndSortedCP)
+	}
 	d.Set("netflow_collector_description", m.NetflowCollectorDescription)
 	d.Set("netflow_collector_group_id", m.NetflowCollectorGroupID)
 	d.Set("netflow_collector_group_name", m.NetflowCollectorGroupName)


### PR DESCRIPTION
need_stc_group_and_sorted_c_p field was not getting updated in tfstate file after terraform apply operation since it is a query param . Terraform would otherwise overwrite it with false (default for a missing boolean).
Fix: Special handling for 'need_stc_grp_and_sorted_c_p' as it is a query param and not returned by API