### PR TITLE
CloudServices model update, CloudNormalCollectorConfig enable fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ VERSION=2.0.21
 OS_ARCH=darwin_amd64
 LDFLAGS = -ldflags "-X terraform-provider-logicmonitor/logicmonitor.ProviderVersion=$(VERSION)"
 
+.PHONY: default build release fmt test testacc
+
 default: build
 
 build:
@@ -27,6 +29,9 @@ release:
 	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
 	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
+
+fmt:
+	go fmt ./...
 
 test:
 	go test -i $(TEST) || exit 1

--- a/client/collector/add_collector_parameters.go
+++ b/client/collector/add_collector_parameters.go
@@ -55,10 +55,12 @@ func NewAddCollectorParamsWithHTTPClient(client *http.Client) *AddCollectorParam
 	}
 }
 
-/* AddCollectorParams contains all the parameters to send to the API endpoint
-   for the add collector operation.
+/*
+AddCollectorParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the add collector operation.
+
+	Typically these are written to a http.Request.
 */
 type AddCollectorParams struct {
 

--- a/client/collector/add_collector_responses.go
+++ b/client/collector/add_collector_responses.go
@@ -46,7 +46,8 @@ func NewAddCollectorOK() *AddCollectorOK {
 	return &AddCollectorOK{}
 }
 
-/* AddCollectorOK describes a response with status code 200, with default header values.
+/*
+	AddCollectorOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewAddCollectorDefault(code int) *AddCollectorDefault {
 	}
 }
 
-/* AddCollectorDefault describes a response with status code -1, with default header values.
+/*
+	AddCollectorDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector/delete_collector_by_id_parameters.go
+++ b/client/collector/delete_collector_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewDeleteCollectorByIDParamsWithHTTPClient(client *http.Client) *DeleteColl
 	}
 }
 
-/* DeleteCollectorByIDParams contains all the parameters to send to the API endpoint
-   for the delete collector by Id operation.
+/*
+DeleteCollectorByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete collector by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteCollectorByIDParams struct {
 

--- a/client/collector/delete_collector_by_id_responses.go
+++ b/client/collector/delete_collector_by_id_responses.go
@@ -46,7 +46,8 @@ func NewDeleteCollectorByIDOK() *DeleteCollectorByIDOK {
 	return &DeleteCollectorByIDOK{}
 }
 
-/* DeleteCollectorByIDOK describes a response with status code 200, with default header values.
+/*
+	DeleteCollectorByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -78,7 +79,8 @@ func NewDeleteCollectorByIDDefault(code int) *DeleteCollectorByIDDefault {
 	}
 }
 
-/* DeleteCollectorByIDDefault describes a response with status code -1, with default header values.
+/*
+	DeleteCollectorByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector/get_collector_by_id_parameters.go
+++ b/client/collector/get_collector_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewGetCollectorByIDParamsWithHTTPClient(client *http.Client) *GetCollectorB
 	}
 }
 
-/* GetCollectorByIDParams contains all the parameters to send to the API endpoint
-   for the get collector by Id operation.
+/*
+GetCollectorByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get collector by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCollectorByIDParams struct {
 

--- a/client/collector/get_collector_by_id_responses.go
+++ b/client/collector/get_collector_by_id_responses.go
@@ -46,7 +46,8 @@ func NewGetCollectorByIDOK() *GetCollectorByIDOK {
 	return &GetCollectorByIDOK{}
 }
 
-/* GetCollectorByIDOK describes a response with status code 200, with default header values.
+/*
+	GetCollectorByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetCollectorByIDDefault(code int) *GetCollectorByIDDefault {
 	}
 }
 
-/* GetCollectorByIDDefault describes a response with status code -1, with default header values.
+/*
+	GetCollectorByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector/get_collector_list_parameters.go
+++ b/client/collector/get_collector_list_parameters.go
@@ -54,10 +54,12 @@ func NewGetCollectorListParamsWithHTTPClient(client *http.Client) *GetCollectorL
 	}
 }
 
-/* GetCollectorListParams contains all the parameters to send to the API endpoint
-   for the get collector list operation.
+/*
+GetCollectorListParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get collector list operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCollectorListParams struct {
 

--- a/client/collector/get_collector_list_responses.go
+++ b/client/collector/get_collector_list_responses.go
@@ -46,7 +46,8 @@ func NewGetCollectorListOK() *GetCollectorListOK {
 	return &GetCollectorListOK{}
 }
 
-/* GetCollectorListOK describes a response with status code 200, with default header values.
+/*
+	GetCollectorListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetCollectorListDefault(code int) *GetCollectorListDefault {
 	}
 }
 
-/* GetCollectorListDefault describes a response with status code -1, with default header values.
+/*
+	GetCollectorListDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector/misc_get_collector_download_token_parameters.go
+++ b/client/collector/misc_get_collector_download_token_parameters.go
@@ -54,10 +54,12 @@ func NewMiscGetCollectorDownloadTokenParamsWithHTTPClient(client *http.Client) *
 	}
 }
 
-/* MiscGetCollectorDownloadTokenParams contains all the parameters to send to the API endpoint
-   for the misc get collector download token operation.
+/*
+MiscGetCollectorDownloadTokenParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the misc get collector download token operation.
+
+	Typically these are written to a http.Request.
 */
 type MiscGetCollectorDownloadTokenParams struct {
 

--- a/client/collector/misc_get_collector_download_token_responses.go
+++ b/client/collector/misc_get_collector_download_token_responses.go
@@ -46,7 +46,8 @@ func NewMiscGetCollectorDownloadTokenOK() *MiscGetCollectorDownloadTokenOK {
 	return &MiscGetCollectorDownloadTokenOK{}
 }
 
-/* MiscGetCollectorDownloadTokenOK describes a response with status code 200, with default header values.
+/*
+	MiscGetCollectorDownloadTokenOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -78,7 +79,8 @@ func NewMiscGetCollectorDownloadTokenDefault(code int) *MiscGetCollectorDownload
 	}
 }
 
-/* MiscGetCollectorDownloadTokenDefault describes a response with status code -1, with default header values.
+/*
+	MiscGetCollectorDownloadTokenDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector/update_collector_by_id_parameters.go
+++ b/client/collector/update_collector_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewUpdateCollectorByIDParamsWithHTTPClient(client *http.Client) *UpdateColl
 	}
 }
 
-/* UpdateCollectorByIDParams contains all the parameters to send to the API endpoint
-   for the update collector by Id operation.
+/*
+UpdateCollectorByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update collector by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateCollectorByIDParams struct {
 

--- a/client/collector/update_collector_by_id_responses.go
+++ b/client/collector/update_collector_by_id_responses.go
@@ -46,7 +46,8 @@ func NewUpdateCollectorByIDOK() *UpdateCollectorByIDOK {
 	return &UpdateCollectorByIDOK{}
 }
 
-/* UpdateCollectorByIDOK describes a response with status code 200, with default header values.
+/*
+	UpdateCollectorByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewUpdateCollectorByIDDefault(code int) *UpdateCollectorByIDDefault {
 	}
 }
 
-/* UpdateCollectorByIDDefault describes a response with status code -1, with default header values.
+/*
+	UpdateCollectorByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector_group/add_collector_group_parameters.go
+++ b/client/collector_group/add_collector_group_parameters.go
@@ -55,10 +55,12 @@ func NewAddCollectorGroupParamsWithHTTPClient(client *http.Client) *AddCollector
 	}
 }
 
-/* AddCollectorGroupParams contains all the parameters to send to the API endpoint
-   for the add collector group operation.
+/*
+AddCollectorGroupParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the add collector group operation.
+
+	Typically these are written to a http.Request.
 */
 type AddCollectorGroupParams struct {
 

--- a/client/collector_group/add_collector_group_responses.go
+++ b/client/collector_group/add_collector_group_responses.go
@@ -46,7 +46,8 @@ func NewAddCollectorGroupOK() *AddCollectorGroupOK {
 	return &AddCollectorGroupOK{}
 }
 
-/* AddCollectorGroupOK describes a response with status code 200, with default header values.
+/*
+	AddCollectorGroupOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewAddCollectorGroupDefault(code int) *AddCollectorGroupDefault {
 	}
 }
 
-/* AddCollectorGroupDefault describes a response with status code -1, with default header values.
+/*
+	AddCollectorGroupDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector_group/delete_collector_group_by_id_parameters.go
+++ b/client/collector_group/delete_collector_group_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewDeleteCollectorGroupByIDParamsWithHTTPClient(client *http.Client) *Delet
 	}
 }
 
-/* DeleteCollectorGroupByIDParams contains all the parameters to send to the API endpoint
-   for the delete collector group by Id operation.
+/*
+DeleteCollectorGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete collector group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteCollectorGroupByIDParams struct {
 

--- a/client/collector_group/delete_collector_group_by_id_responses.go
+++ b/client/collector_group/delete_collector_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewDeleteCollectorGroupByIDOK() *DeleteCollectorGroupByIDOK {
 	return &DeleteCollectorGroupByIDOK{}
 }
 
-/* DeleteCollectorGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	DeleteCollectorGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -78,7 +79,8 @@ func NewDeleteCollectorGroupByIDDefault(code int) *DeleteCollectorGroupByIDDefau
 	}
 }
 
-/* DeleteCollectorGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	DeleteCollectorGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector_group/get_collector_group_by_id_parameters.go
+++ b/client/collector_group/get_collector_group_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewGetCollectorGroupByIDParamsWithHTTPClient(client *http.Client) *GetColle
 	}
 }
 
-/* GetCollectorGroupByIDParams contains all the parameters to send to the API endpoint
-   for the get collector group by Id operation.
+/*
+GetCollectorGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get collector group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCollectorGroupByIDParams struct {
 

--- a/client/collector_group/get_collector_group_by_id_responses.go
+++ b/client/collector_group/get_collector_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewGetCollectorGroupByIDOK() *GetCollectorGroupByIDOK {
 	return &GetCollectorGroupByIDOK{}
 }
 
-/* GetCollectorGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	GetCollectorGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetCollectorGroupByIDDefault(code int) *GetCollectorGroupByIDDefault {
 	}
 }
 
-/* GetCollectorGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	GetCollectorGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector_group/get_collector_group_list_parameters.go
+++ b/client/collector_group/get_collector_group_list_parameters.go
@@ -54,10 +54,12 @@ func NewGetCollectorGroupListParamsWithHTTPClient(client *http.Client) *GetColle
 	}
 }
 
-/* GetCollectorGroupListParams contains all the parameters to send to the API endpoint
-   for the get collector group list operation.
+/*
+GetCollectorGroupListParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get collector group list operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCollectorGroupListParams struct {
 

--- a/client/collector_group/get_collector_group_list_responses.go
+++ b/client/collector_group/get_collector_group_list_responses.go
@@ -46,7 +46,8 @@ func NewGetCollectorGroupListOK() *GetCollectorGroupListOK {
 	return &GetCollectorGroupListOK{}
 }
 
-/* GetCollectorGroupListOK describes a response with status code 200, with default header values.
+/*
+	GetCollectorGroupListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetCollectorGroupListDefault(code int) *GetCollectorGroupListDefault {
 	}
 }
 
-/* GetCollectorGroupListDefault describes a response with status code -1, with default header values.
+/*
+	GetCollectorGroupListDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/collector_group/update_collector_group_by_id_parameters.go
+++ b/client/collector_group/update_collector_group_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewUpdateCollectorGroupByIDParamsWithHTTPClient(client *http.Client) *Updat
 	}
 }
 
-/* UpdateCollectorGroupByIDParams contains all the parameters to send to the API endpoint
-   for the update collector group by Id operation.
+/*
+UpdateCollectorGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update collector group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateCollectorGroupByIDParams struct {
 

--- a/client/collector_group/update_collector_group_by_id_responses.go
+++ b/client/collector_group/update_collector_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewUpdateCollectorGroupByIDOK() *UpdateCollectorGroupByIDOK {
 	return &UpdateCollectorGroupByIDOK{}
 }
 
-/* UpdateCollectorGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	UpdateCollectorGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewUpdateCollectorGroupByIDDefault(code int) *UpdateCollectorGroupByIDDefau
 	}
 }
 
-/* UpdateCollectorGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	UpdateCollectorGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/add_dashboard_parameters.go
+++ b/client/dashboard/add_dashboard_parameters.go
@@ -55,10 +55,12 @@ func NewAddDashboardParamsWithHTTPClient(client *http.Client) *AddDashboardParam
 	}
 }
 
-/* AddDashboardParams contains all the parameters to send to the API endpoint
-   for the add dashboard operation.
+/*
+AddDashboardParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the add dashboard operation.
+
+	Typically these are written to a http.Request.
 */
 type AddDashboardParams struct {
 

--- a/client/dashboard/add_dashboard_responses.go
+++ b/client/dashboard/add_dashboard_responses.go
@@ -46,7 +46,8 @@ func NewAddDashboardOK() *AddDashboardOK {
 	return &AddDashboardOK{}
 }
 
-/* AddDashboardOK describes a response with status code 200, with default header values.
+/*
+	AddDashboardOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewAddDashboardDefault(code int) *AddDashboardDefault {
 	}
 }
 
-/* AddDashboardDefault describes a response with status code -1, with default header values.
+/*
+	AddDashboardDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/delete_dashboard_by_id_parameters.go
+++ b/client/dashboard/delete_dashboard_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewDeleteDashboardByIDParamsWithHTTPClient(client *http.Client) *DeleteDash
 	}
 }
 
-/* DeleteDashboardByIDParams contains all the parameters to send to the API endpoint
-   for the delete dashboard by Id operation.
+/*
+DeleteDashboardByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete dashboard by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteDashboardByIDParams struct {
 

--- a/client/dashboard/delete_dashboard_by_id_responses.go
+++ b/client/dashboard/delete_dashboard_by_id_responses.go
@@ -46,7 +46,8 @@ func NewDeleteDashboardByIDOK() *DeleteDashboardByIDOK {
 	return &DeleteDashboardByIDOK{}
 }
 
-/* DeleteDashboardByIDOK describes a response with status code 200, with default header values.
+/*
+	DeleteDashboardByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -78,7 +79,8 @@ func NewDeleteDashboardByIDDefault(code int) *DeleteDashboardByIDDefault {
 	}
 }
 
-/* DeleteDashboardByIDDefault describes a response with status code -1, with default header values.
+/*
+	DeleteDashboardByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/get_dashboard_by_id_parameters.go
+++ b/client/dashboard/get_dashboard_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewGetDashboardByIDParamsWithHTTPClient(client *http.Client) *GetDashboardB
 	}
 }
 
-/* GetDashboardByIDParams contains all the parameters to send to the API endpoint
-   for the get dashboard by Id operation.
+/*
+GetDashboardByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get dashboard by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDashboardByIDParams struct {
 

--- a/client/dashboard/get_dashboard_by_id_responses.go
+++ b/client/dashboard/get_dashboard_by_id_responses.go
@@ -46,7 +46,8 @@ func NewGetDashboardByIDOK() *GetDashboardByIDOK {
 	return &GetDashboardByIDOK{}
 }
 
-/* GetDashboardByIDOK describes a response with status code 200, with default header values.
+/*
+	GetDashboardByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDashboardByIDDefault(code int) *GetDashboardByIDDefault {
 	}
 }
 
-/* GetDashboardByIDDefault describes a response with status code -1, with default header values.
+/*
+	GetDashboardByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/get_dashboard_list_parameters.go
+++ b/client/dashboard/get_dashboard_list_parameters.go
@@ -54,10 +54,12 @@ func NewGetDashboardListParamsWithHTTPClient(client *http.Client) *GetDashboardL
 	}
 }
 
-/* GetDashboardListParams contains all the parameters to send to the API endpoint
-   for the get dashboard list operation.
+/*
+GetDashboardListParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get dashboard list operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDashboardListParams struct {
 

--- a/client/dashboard/get_dashboard_list_responses.go
+++ b/client/dashboard/get_dashboard_list_responses.go
@@ -46,7 +46,8 @@ func NewGetDashboardListOK() *GetDashboardListOK {
 	return &GetDashboardListOK{}
 }
 
-/* GetDashboardListOK describes a response with status code 200, with default header values.
+/*
+	GetDashboardListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDashboardListDefault(code int) *GetDashboardListDefault {
 	}
 }
 
-/* GetDashboardListDefault describes a response with status code -1, with default header values.
+/*
+	GetDashboardListDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/get_widget_list_by_dashboard_id_parameters.go
+++ b/client/dashboard/get_widget_list_by_dashboard_id_parameters.go
@@ -53,10 +53,12 @@ func NewGetWidgetListByDashboardIDParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/* GetWidgetListByDashboardIDParams contains all the parameters to send to the API endpoint
-   for the get widget list by dashboard Id operation.
+/*
+GetWidgetListByDashboardIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get widget list by dashboard Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetWidgetListByDashboardIDParams struct {
 

--- a/client/dashboard/get_widget_list_by_dashboard_id_responses.go
+++ b/client/dashboard/get_widget_list_by_dashboard_id_responses.go
@@ -46,7 +46,8 @@ func NewGetWidgetListByDashboardIDOK() *GetWidgetListByDashboardIDOK {
 	return &GetWidgetListByDashboardIDOK{}
 }
 
-/* GetWidgetListByDashboardIDOK describes a response with status code 200, with default header values.
+/*
+	GetWidgetListByDashboardIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetWidgetListByDashboardIDDefault(code int) *GetWidgetListByDashboardIDD
 	}
 }
 
-/* GetWidgetListByDashboardIDDefault describes a response with status code -1, with default header values.
+/*
+	GetWidgetListByDashboardIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/patch_dashboard_by_id_parameters.go
+++ b/client/dashboard/patch_dashboard_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewPatchDashboardByIDParamsWithHTTPClient(client *http.Client) *PatchDashbo
 	}
 }
 
-/* PatchDashboardByIDParams contains all the parameters to send to the API endpoint
-   for the patch dashboard by Id operation.
+/*
+PatchDashboardByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the patch dashboard by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type PatchDashboardByIDParams struct {
 

--- a/client/dashboard/patch_dashboard_by_id_responses.go
+++ b/client/dashboard/patch_dashboard_by_id_responses.go
@@ -46,7 +46,8 @@ func NewPatchDashboardByIDOK() *PatchDashboardByIDOK {
 	return &PatchDashboardByIDOK{}
 }
 
-/* PatchDashboardByIDOK describes a response with status code 200, with default header values.
+/*
+	PatchDashboardByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewPatchDashboardByIDDefault(code int) *PatchDashboardByIDDefault {
 	}
 }
 
-/* PatchDashboardByIDDefault describes a response with status code -1, with default header values.
+/*
+	PatchDashboardByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard/update_dashboard_by_id_parameters.go
+++ b/client/dashboard/update_dashboard_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewUpdateDashboardByIDParamsWithHTTPClient(client *http.Client) *UpdateDash
 	}
 }
 
-/* UpdateDashboardByIDParams contains all the parameters to send to the API endpoint
-   for the update dashboard by Id operation.
+/*
+UpdateDashboardByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update dashboard by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateDashboardByIDParams struct {
 

--- a/client/dashboard/update_dashboard_by_id_responses.go
+++ b/client/dashboard/update_dashboard_by_id_responses.go
@@ -46,7 +46,8 @@ func NewUpdateDashboardByIDOK() *UpdateDashboardByIDOK {
 	return &UpdateDashboardByIDOK{}
 }
 
-/* UpdateDashboardByIDOK describes a response with status code 200, with default header values.
+/*
+	UpdateDashboardByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewUpdateDashboardByIDDefault(code int) *UpdateDashboardByIDDefault {
 	}
 }
 
-/* UpdateDashboardByIDDefault describes a response with status code -1, with default header values.
+/*
+	UpdateDashboardByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard_group/add_dashboard_group_parameters.go
+++ b/client/dashboard_group/add_dashboard_group_parameters.go
@@ -55,10 +55,12 @@ func NewAddDashboardGroupParamsWithHTTPClient(client *http.Client) *AddDashboard
 	}
 }
 
-/* AddDashboardGroupParams contains all the parameters to send to the API endpoint
-   for the add dashboard group operation.
+/*
+AddDashboardGroupParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the add dashboard group operation.
+
+	Typically these are written to a http.Request.
 */
 type AddDashboardGroupParams struct {
 

--- a/client/dashboard_group/add_dashboard_group_responses.go
+++ b/client/dashboard_group/add_dashboard_group_responses.go
@@ -46,7 +46,8 @@ func NewAddDashboardGroupOK() *AddDashboardGroupOK {
 	return &AddDashboardGroupOK{}
 }
 
-/* AddDashboardGroupOK describes a response with status code 200, with default header values.
+/*
+	AddDashboardGroupOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewAddDashboardGroupDefault(code int) *AddDashboardGroupDefault {
 	}
 }
 
-/* AddDashboardGroupDefault describes a response with status code -1, with default header values.
+/*
+	AddDashboardGroupDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard_group/delete_dashboard_group_by_id_parameters.go
+++ b/client/dashboard_group/delete_dashboard_group_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewDeleteDashboardGroupByIDParamsWithHTTPClient(client *http.Client) *Delet
 	}
 }
 
-/* DeleteDashboardGroupByIDParams contains all the parameters to send to the API endpoint
-   for the delete dashboard group by Id operation.
+/*
+DeleteDashboardGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete dashboard group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteDashboardGroupByIDParams struct {
 

--- a/client/dashboard_group/delete_dashboard_group_by_id_responses.go
+++ b/client/dashboard_group/delete_dashboard_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewDeleteDashboardGroupByIDOK() *DeleteDashboardGroupByIDOK {
 	return &DeleteDashboardGroupByIDOK{}
 }
 
-/* DeleteDashboardGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	DeleteDashboardGroupByIDOK describes a response with status code 200, with default header values.
 
 OK
 */
@@ -78,7 +79,8 @@ func NewDeleteDashboardGroupByIDDefault(code int) *DeleteDashboardGroupByIDDefau
 	}
 }
 
-/* DeleteDashboardGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	DeleteDashboardGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard_group/get_dashboard_group_by_id_parameters.go
+++ b/client/dashboard_group/get_dashboard_group_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewGetDashboardGroupByIDParamsWithHTTPClient(client *http.Client) *GetDashb
 	}
 }
 
-/* GetDashboardGroupByIDParams contains all the parameters to send to the API endpoint
-   for the get dashboard group by Id operation.
+/*
+GetDashboardGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get dashboard group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDashboardGroupByIDParams struct {
 

--- a/client/dashboard_group/get_dashboard_group_by_id_responses.go
+++ b/client/dashboard_group/get_dashboard_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewGetDashboardGroupByIDOK() *GetDashboardGroupByIDOK {
 	return &GetDashboardGroupByIDOK{}
 }
 
-/* GetDashboardGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	GetDashboardGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDashboardGroupByIDDefault(code int) *GetDashboardGroupByIDDefault {
 	}
 }
 
-/* GetDashboardGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	GetDashboardGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard_group/get_dashboard_group_list_parameters.go
+++ b/client/dashboard_group/get_dashboard_group_list_parameters.go
@@ -54,10 +54,12 @@ func NewGetDashboardGroupListParamsWithHTTPClient(client *http.Client) *GetDashb
 	}
 }
 
-/* GetDashboardGroupListParams contains all the parameters to send to the API endpoint
-   for the get dashboard group list operation.
+/*
+GetDashboardGroupListParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get dashboard group list operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDashboardGroupListParams struct {
 

--- a/client/dashboard_group/get_dashboard_group_list_responses.go
+++ b/client/dashboard_group/get_dashboard_group_list_responses.go
@@ -46,7 +46,8 @@ func NewGetDashboardGroupListOK() *GetDashboardGroupListOK {
 	return &GetDashboardGroupListOK{}
 }
 
-/* GetDashboardGroupListOK describes a response with status code 200, with default header values.
+/*
+	GetDashboardGroupListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDashboardGroupListDefault(code int) *GetDashboardGroupListDefault {
 	}
 }
 
-/* GetDashboardGroupListDefault describes a response with status code -1, with default header values.
+/*
+	GetDashboardGroupListDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard_group/patch_dashboard_group_by_id_parameters.go
+++ b/client/dashboard_group/patch_dashboard_group_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewPatchDashboardGroupByIDParamsWithHTTPClient(client *http.Client) *PatchD
 	}
 }
 
-/* PatchDashboardGroupByIDParams contains all the parameters to send to the API endpoint
-   for the patch dashboard group by Id operation.
+/*
+PatchDashboardGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the patch dashboard group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type PatchDashboardGroupByIDParams struct {
 

--- a/client/dashboard_group/patch_dashboard_group_by_id_responses.go
+++ b/client/dashboard_group/patch_dashboard_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewPatchDashboardGroupByIDOK() *PatchDashboardGroupByIDOK {
 	return &PatchDashboardGroupByIDOK{}
 }
 
-/* PatchDashboardGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	PatchDashboardGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewPatchDashboardGroupByIDDefault(code int) *PatchDashboardGroupByIDDefault
 	}
 }
 
-/* PatchDashboardGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	PatchDashboardGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/dashboard_group/update_dashboard_group_by_id_parameters.go
+++ b/client/dashboard_group/update_dashboard_group_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewUpdateDashboardGroupByIDParamsWithHTTPClient(client *http.Client) *Updat
 	}
 }
 
-/* UpdateDashboardGroupByIDParams contains all the parameters to send to the API endpoint
-   for the update dashboard group by Id operation.
+/*
+UpdateDashboardGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update dashboard group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateDashboardGroupByIDParams struct {
 

--- a/client/dashboard_group/update_dashboard_group_by_id_responses.go
+++ b/client/dashboard_group/update_dashboard_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewUpdateDashboardGroupByIDOK() *UpdateDashboardGroupByIDOK {
 	return &UpdateDashboardGroupByIDOK{}
 }
 
-/* UpdateDashboardGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	UpdateDashboardGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewUpdateDashboardGroupByIDDefault(code int) *UpdateDashboardGroupByIDDefau
 	}
 }
 
-/* UpdateDashboardGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	UpdateDashboardGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/data_resource_aws_external_id/get_aws_external_id_parameters.go
+++ b/client/data_resource_aws_external_id/get_aws_external_id_parameters.go
@@ -53,10 +53,12 @@ func NewGetAwsExternalIDParamsWithHTTPClient(client *http.Client) *GetAwsExterna
 	}
 }
 
-/* GetAwsExternalIDParams contains all the parameters to send to the API endpoint
-   for the get aws external Id operation.
+/*
+GetAwsExternalIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get aws external Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetAwsExternalIDParams struct {
 	timeout    time.Duration

--- a/client/data_resource_aws_external_id/get_aws_external_id_responses.go
+++ b/client/data_resource_aws_external_id/get_aws_external_id_responses.go
@@ -46,7 +46,8 @@ func NewGetAwsExternalIDOK() *GetAwsExternalIDOK {
 	return &GetAwsExternalIDOK{}
 }
 
-/* GetAwsExternalIDOK describes a response with status code 200, with default header values.
+/*
+	GetAwsExternalIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetAwsExternalIDDefault(code int) *GetAwsExternalIDDefault {
 	}
 }
 
-/* GetAwsExternalIDDefault describes a response with status code -1, with default header values.
+/*
+	GetAwsExternalIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device/add_device_responses.go
+++ b/client/device/add_device_responses.go
@@ -46,7 +46,8 @@ func NewAddDeviceOK() *AddDeviceOK {
 	return &AddDeviceOK{}
 }
 
-/* AddDeviceOK describes a response with status code 200, with default header values.
+/*
+	AddDeviceOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewAddDeviceDefault(code int) *AddDeviceDefault {
 	}
 }
 
-/* AddDeviceDefault describes a response with status code -1, with default header values.
+/*
+	AddDeviceDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device/delete_device_by_id_parameters.go
+++ b/client/device/delete_device_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewDeleteDeviceByIDParamsWithHTTPClient(client *http.Client) *DeleteDeviceB
 	}
 }
 
-/* DeleteDeviceByIDParams contains all the parameters to send to the API endpoint
-   for the delete device by Id operation.
+/*
+DeleteDeviceByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete device by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteDeviceByIDParams struct {
 

--- a/client/device/delete_device_by_id_responses.go
+++ b/client/device/delete_device_by_id_responses.go
@@ -46,7 +46,8 @@ func NewDeleteDeviceByIDOK() *DeleteDeviceByIDOK {
 	return &DeleteDeviceByIDOK{}
 }
 
-/* DeleteDeviceByIDOK describes a response with status code 200, with default header values.
+/*
+	DeleteDeviceByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -78,7 +79,8 @@ func NewDeleteDeviceByIDDefault(code int) *DeleteDeviceByIDDefault {
 	}
 }
 
-/* DeleteDeviceByIDDefault describes a response with status code -1, with default header values.
+/*
+	DeleteDeviceByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device/get_device_by_id_responses.go
+++ b/client/device/get_device_by_id_responses.go
@@ -46,7 +46,8 @@ func NewGetDeviceByIDOK() *GetDeviceByIDOK {
 	return &GetDeviceByIDOK{}
 }
 
-/* GetDeviceByIDOK describes a response with status code 200, with default header values.
+/*
+	GetDeviceByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDeviceByIDDefault(code int) *GetDeviceByIDDefault {
 	}
 }
 
-/* GetDeviceByIDDefault describes a response with status code -1, with default header values.
+/*
+	GetDeviceByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device/get_device_list_parameters.go
+++ b/client/device/get_device_list_parameters.go
@@ -54,10 +54,12 @@ func NewGetDeviceListParamsWithHTTPClient(client *http.Client) *GetDeviceListPar
 	}
 }
 
-/* GetDeviceListParams contains all the parameters to send to the API endpoint
-   for the get device list operation.
+/*
+GetDeviceListParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get device list operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDeviceListParams struct {
 

--- a/client/device/get_device_list_responses.go
+++ b/client/device/get_device_list_responses.go
@@ -46,7 +46,8 @@ func NewGetDeviceListOK() *GetDeviceListOK {
 	return &GetDeviceListOK{}
 }
 
-/* GetDeviceListOK describes a response with status code 200, with default header values.
+/*
+	GetDeviceListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDeviceListDefault(code int) *GetDeviceListDefault {
 	}
 }
 
-/* GetDeviceListDefault describes a response with status code -1, with default header values.
+/*
+	GetDeviceListDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device/update_device_responses.go
+++ b/client/device/update_device_responses.go
@@ -46,7 +46,8 @@ func NewUpdateDeviceOK() *UpdateDeviceOK {
 	return &UpdateDeviceOK{}
 }
 
-/* UpdateDeviceOK describes a response with status code 200, with default header values.
+/*
+	UpdateDeviceOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewUpdateDeviceDefault(code int) *UpdateDeviceDefault {
 	}
 }
 
-/* UpdateDeviceDefault describes a response with status code -1, with default header values.
+/*
+	UpdateDeviceDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device_group/add_device_group_parameters.go
+++ b/client/device_group/add_device_group_parameters.go
@@ -55,10 +55,12 @@ func NewAddDeviceGroupParamsWithHTTPClient(client *http.Client) *AddDeviceGroupP
 	}
 }
 
-/* AddDeviceGroupParams contains all the parameters to send to the API endpoint
-   for the add device group operation.
+/*
+AddDeviceGroupParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the add device group operation.
+
+	Typically these are written to a http.Request.
 */
 type AddDeviceGroupParams struct {
 

--- a/client/device_group/add_device_group_responses.go
+++ b/client/device_group/add_device_group_responses.go
@@ -46,7 +46,8 @@ func NewAddDeviceGroupOK() *AddDeviceGroupOK {
 	return &AddDeviceGroupOK{}
 }
 
-/* AddDeviceGroupOK describes a response with status code 200, with default header values.
+/*
+	AddDeviceGroupOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewAddDeviceGroupDefault(code int) *AddDeviceGroupDefault {
 	}
 }
 
-/* AddDeviceGroupDefault describes a response with status code -1, with default header values.
+/*
+	AddDeviceGroupDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device_group/delete_device_group_by_id_parameters.go
+++ b/client/device_group/delete_device_group_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewDeleteDeviceGroupByIDParamsWithHTTPClient(client *http.Client) *DeleteDe
 	}
 }
 
-/* DeleteDeviceGroupByIDParams contains all the parameters to send to the API endpoint
-   for the delete device group by Id operation.
+/*
+DeleteDeviceGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete device group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteDeviceGroupByIDParams struct {
 

--- a/client/device_group/delete_device_group_by_id_responses.go
+++ b/client/device_group/delete_device_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewDeleteDeviceGroupByIDOK() *DeleteDeviceGroupByIDOK {
 	return &DeleteDeviceGroupByIDOK{}
 }
 
-/* DeleteDeviceGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	DeleteDeviceGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -78,7 +79,8 @@ func NewDeleteDeviceGroupByIDDefault(code int) *DeleteDeviceGroupByIDDefault {
 	}
 }
 
-/* DeleteDeviceGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	DeleteDeviceGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device_group/get_device_group_by_id_parameters.go
+++ b/client/device_group/get_device_group_by_id_parameters.go
@@ -54,10 +54,12 @@ func NewGetDeviceGroupByIDParamsWithHTTPClient(client *http.Client) *GetDeviceGr
 	}
 }
 
-/* GetDeviceGroupByIDParams contains all the parameters to send to the API endpoint
-   for the get device group by Id operation.
+/*
+GetDeviceGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get device group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDeviceGroupByIDParams struct {
 

--- a/client/device_group/get_device_group_by_id_responses.go
+++ b/client/device_group/get_device_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewGetDeviceGroupByIDOK() *GetDeviceGroupByIDOK {
 	return &GetDeviceGroupByIDOK{}
 }
 
-/* GetDeviceGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	GetDeviceGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDeviceGroupByIDDefault(code int) *GetDeviceGroupByIDDefault {
 	}
 }
 
-/* GetDeviceGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	GetDeviceGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device_group/get_device_group_list_parameters.go
+++ b/client/device_group/get_device_group_list_parameters.go
@@ -54,10 +54,12 @@ func NewGetDeviceGroupListParamsWithHTTPClient(client *http.Client) *GetDeviceGr
 	}
 }
 
-/* GetDeviceGroupListParams contains all the parameters to send to the API endpoint
-   for the get device group list operation.
+/*
+GetDeviceGroupListParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get device group list operation.
+
+	Typically these are written to a http.Request.
 */
 type GetDeviceGroupListParams struct {
 

--- a/client/device_group/get_device_group_list_responses.go
+++ b/client/device_group/get_device_group_list_responses.go
@@ -46,7 +46,8 @@ func NewGetDeviceGroupListOK() *GetDeviceGroupListOK {
 	return &GetDeviceGroupListOK{}
 }
 
-/* GetDeviceGroupListOK describes a response with status code 200, with default header values.
+/*
+	GetDeviceGroupListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewGetDeviceGroupListDefault(code int) *GetDeviceGroupListDefault {
 	}
 }
 
-/* GetDeviceGroupListDefault describes a response with status code -1, with default header values.
+/*
+	GetDeviceGroupListDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/client/device_group/update_device_group_by_id_parameters.go
+++ b/client/device_group/update_device_group_by_id_parameters.go
@@ -56,10 +56,12 @@ func NewUpdateDeviceGroupByIDParamsWithHTTPClient(client *http.Client) *UpdateDe
 	}
 }
 
-/* UpdateDeviceGroupByIDParams contains all the parameters to send to the API endpoint
-   for the update device group by Id operation.
+/*
+UpdateDeviceGroupByIDParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update device group by Id operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateDeviceGroupByIDParams struct {
 

--- a/client/device_group/update_device_group_by_id_responses.go
+++ b/client/device_group/update_device_group_by_id_responses.go
@@ -46,7 +46,8 @@ func NewUpdateDeviceGroupByIDOK() *UpdateDeviceGroupByIDOK {
 	return &UpdateDeviceGroupByIDOK{}
 }
 
-/* UpdateDeviceGroupByIDOK describes a response with status code 200, with default header values.
+/*
+	UpdateDeviceGroupByIDOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -80,7 +81,8 @@ func NewUpdateDeviceGroupByIDDefault(code int) *UpdateDeviceGroupByIDDefault {
 	}
 }
 
-/* UpdateDeviceGroupByIDDefault describes a response with status code -1, with default header values.
+/*
+	UpdateDeviceGroupByIDDefault describes a response with status code -1, with default header values.
 
 Error
 */

--- a/logicmonitor/schemata/access_group_schema.go
+++ b/logicmonitor/schemata/access_group_schema.go
@@ -1,47 +1,46 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AccessGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"created_by": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"tenant_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -68,12 +67,12 @@ func AccessGroupModel(d map[string]interface{}) *models.AccessGroup {
 	id := int32(d["id"].(int))
 	name := d["name"].(string)
 	tenantID := d["tenant_id"].(string)
-	
-	return &models.AccessGroup {
+
+	return &models.AccessGroup{
 		Description: description,
-		ID: id,
-		Name: &name,
-		TenantID: tenantID,
+		ID:          id,
+		Name:        &name,
+		TenantID:    tenantID,
 	}
 }
 

--- a/logicmonitor/schemata/alert_rule_pagination_response_schema.go
+++ b/logicmonitor/schemata/alert_rule_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AlertRulePaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*AlertRule 
+			Type: schema.TypeList, //GoType: []*AlertRule
 			Elem: &schema.Resource{
 				Schema: AlertRuleSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetAlertRulePaginationResponseSubResourceData(m []*models.AlertRulePaginati
 func AlertRulePaginationResponseModel(d map[string]interface{}) *models.AlertRulePaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.AlertRule)
-	
-	return &models.AlertRulePaginationResponse {
+
+	return &models.AlertRulePaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/alert_rule_schema.go
+++ b/logicmonitor/schemata/alert_rule_schema.go
@@ -1,38 +1,38 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func AlertRuleSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"datapoint": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"datasource": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"device_groups": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Required: true,
 		},
-		
+
 		"devices": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Required: true,
 		},
-		
+
 		"escalating_chain": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -40,98 +40,96 @@ func AlertRuleSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"escalating_chain_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"escalation_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"instance": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"level_str": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"priority": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"resource_properties": {
-			Type: schema.TypeList, //GoType: []*DeviceProperty  
+			Type: schema.TypeList, //GoType: []*DeviceProperty
 			Elem: &schema.Resource{
 				Schema: DevicePropertySchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"send_anomaly_suppressed_alert": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"suppress_alert_ack_sdt": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"suppress_alert_clear": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and AlertRuleSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceAlertRuleSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"datapoint": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"datasource": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_groups": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"devices": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"escalating_chain": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -139,70 +137,70 @@ func DataSourceAlertRuleSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"escalating_chain_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"escalation_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"instance": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"level_str": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"priority": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"resource_properties": {
-			Type: schema.TypeList, //GoType: []*DeviceProperty 
+			Type: schema.TypeList, //GoType: []*DeviceProperty
 			Elem: &schema.Resource{
 				Schema: DevicePropertySchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"send_anomaly_suppressed_alert": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"suppress_alert_ack_sdt": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"suppress_alert_clear": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -268,23 +266,23 @@ func AlertRuleModel(d *schema.ResourceData) *models.AlertRule {
 	sendAnomalySuppressedAlert := d.Get("send_anomaly_suppressed_alert").(bool)
 	suppressAlertAckSdt := d.Get("suppress_alert_ack_sdt").(bool)
 	suppressAlertClear := d.Get("suppress_alert_clear").(bool)
-	
-	return &models.AlertRule {
-		Datapoint: &datapoint,
-		Datasource: &datasource,
-		DeviceGroups: deviceGroups,
-		Devices: devices,
-		EscalatingChainID: &escalatingChainID,
-		EscalationInterval: &escalationInterval,
-		ID: int32(id),
-		Instance: &instance,
-		LevelStr: levelStr,
-		Name: &name,
-		Priority: &priority,
-		ResourceProperties: resourceProperties,
+
+	return &models.AlertRule{
+		Datapoint:                  &datapoint,
+		Datasource:                 &datasource,
+		DeviceGroups:               deviceGroups,
+		Devices:                    devices,
+		EscalatingChainID:          &escalatingChainID,
+		EscalationInterval:         &escalationInterval,
+		ID:                         int32(id),
+		Instance:                   &instance,
+		LevelStr:                   levelStr,
+		Name:                       &name,
+		Priority:                   &priority,
+		ResourceProperties:         resourceProperties,
 		SendAnomalySuppressedAlert: sendAnomalySuppressedAlert,
-		SuppressAlertAckSdt: suppressAlertAckSdt,
-		SuppressAlertClear: suppressAlertClear,
+		SuppressAlertAckSdt:        suppressAlertAckSdt,
+		SuppressAlertClear:         suppressAlertClear,
 	}
 }
 func GetAlertRulePropertyFields() (t []string) {

--- a/logicmonitor/schemata/authentication_schema.go
+++ b/logicmonitor/schemata/authentication_schema.go
@@ -1,33 +1,32 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AuthenticationSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"domain": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"password": {
-			Type: schema.TypeString,
+			Type:      schema.TypeString,
 			Sensitive: true,
-			Required: true,
+			Required:  true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"user_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -51,11 +50,11 @@ func AuthenticationModel(d map[string]interface{}) *models.Authentication {
 	password := d["password"].(string)
 	typeVar := d["type"].(string)
 	userName := d["user_name"].(string)
-	
-	return &models.Authentication {
-		Domain: domain,
+
+	return &models.Authentication{
+		Domain:   domain,
 		Password: &password,
-		Type: &typeVar,
+		Type:     &typeVar,
 		UserName: &userName,
 	}
 }

--- a/logicmonitor/schemata/auto_discovery_configuration_schema.go
+++ b/logicmonitor/schemata/auto_discovery_configuration_schema.go
@@ -1,47 +1,47 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func AutoDiscoveryConfigurationSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"data_source_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"delete_inactive_instance": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"disable_instance": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"filters": {
-			Type: schema.TypeList, //GoType: []*AutoDiscoveryFilter  
+			Type: schema.TypeList, //GoType: []*AutoDiscoveryFilter
 			Elem: &schema.Resource{
 				Schema: AutoDiscoveryFilterSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"instance_auto_group_method": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"instance_auto_group_method_params": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"method": {
 			Type: schema.TypeList, //GoType: AutoDiscoveryMethod
 			Elem: &schema.Resource{
@@ -49,17 +49,16 @@ func AutoDiscoveryConfigurationSchema() map[string]*schema.Schema {
 			},
 			Required: true,
 		},
-		
+
 		"persistent_instance": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"schedule_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -96,16 +95,16 @@ func AutoDiscoveryConfigurationModel(d map[string]interface{}) *models.AutoDisco
 	}
 	persistentInstance := d["persistent_instance"].(bool)
 	scheduleInterval := int32(d["schedule_interval"].(int))
-	
-	return &models.AutoDiscoveryConfiguration {
-		DeleteInactiveInstance: deleteInactiveInstance,
-		DisableInstance: disableInstance,
-		Filters: filters,
-		InstanceAutoGroupMethod: instanceAutoGroupMethod,
+
+	return &models.AutoDiscoveryConfiguration{
+		DeleteInactiveInstance:        deleteInactiveInstance,
+		DisableInstance:               disableInstance,
+		Filters:                       filters,
+		InstanceAutoGroupMethod:       instanceAutoGroupMethod,
 		InstanceAutoGroupMethodParams: instanceAutoGroupMethodParams,
-		Method: method,
-		PersistentInstance: persistentInstance,
-		ScheduleInterval: scheduleInterval,
+		Method:                        method,
+		PersistentInstance:            persistentInstance,
+		ScheduleInterval:              scheduleInterval,
 	}
 }
 

--- a/logicmonitor/schemata/auto_discovery_filter_schema.go
+++ b/logicmonitor/schemata/auto_discovery_filter_schema.go
@@ -1,32 +1,31 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AutoDiscoveryFilterSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"attribute": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"comment": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"operation": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -50,12 +49,12 @@ func AutoDiscoveryFilterModel(d map[string]interface{}) *models.AutoDiscoveryFil
 	comment := d["comment"].(string)
 	operation := d["operation"].(string)
 	value := d["value"].(string)
-	
-	return &models.AutoDiscoveryFilter {
+
+	return &models.AutoDiscoveryFilter{
 		Attribute: &attribute,
-		Comment: comment,
+		Comment:   comment,
 		Operation: &operation,
-		Value: value,
+		Value:     value,
 	}
 }
 

--- a/logicmonitor/schemata/auto_discovery_method_schema.go
+++ b/logicmonitor/schemata/auto_discovery_method_schema.go
@@ -1,17 +1,16 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AutoDiscoveryMethodSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -29,8 +28,8 @@ func SetAutoDiscoveryMethodSubResourceData(m []*models.AutoDiscoveryMethod) (d [
 func AutoDiscoveryMethodModel(d map[string]interface{}) *models.AutoDiscoveryMethod {
 	// assume that the incoming map only contains the relevant resource data
 	name := d["name"].(string)
-	
-	return &models.AutoDiscoveryMethod {
+
+	return &models.AutoDiscoveryMethod{
 		Name: &name,
 	}
 }

--- a/logicmonitor/schemata/automatic_upgrade_info_schema.go
+++ b/logicmonitor/schemata/automatic_upgrade_info_schema.go
@@ -1,62 +1,61 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AutomaticUpgradeInfoSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"created_by": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"day_of_week": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"hour": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"level": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"minute": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"occurrence": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"timezone": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -89,15 +88,15 @@ func AutomaticUpgradeInfoModel(d map[string]interface{}) *models.AutomaticUpgrad
 	occurrence := d["occurrence"].(string)
 	timezone := d["timezone"].(string)
 	version := d["version"].(string)
-	
-	return &models.AutomaticUpgradeInfo {
-		DayOfWeek: &dayOfWeek,
+
+	return &models.AutomaticUpgradeInfo{
+		DayOfWeek:   &dayOfWeek,
 		Description: description,
-		Hour: &hour,
-		Minute: &minute,
-		Occurrence: &occurrence,
-		Timezone: timezone,
-		Version: &version,
+		Hour:        &hour,
+		Minute:      &minute,
+		Occurrence:  &occurrence,
+		Timezone:    timezone,
+		Version:     &version,
 	}
 }
 

--- a/logicmonitor/schemata/aws_account_test_result_schema.go
+++ b/logicmonitor/schemata/aws_account_test_result_schema.go
@@ -1,32 +1,31 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func AwsAccountTestResultSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"detail_link": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"no_permission_services": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"non_permission_errors": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -48,11 +47,11 @@ func AwsAccountTestResultModel(d map[string]interface{}) *models.AwsAccountTestR
 	detailLink := d["detail_link"].(string)
 	noPermissionServices := utils.ConvertSetToStringSlice(d["no_permission_services"].(*schema.Set))
 	nonPermissionErrors := utils.ConvertSetToStringSlice(d["non_permission_errors"].(*schema.Set))
-	
-	return &models.AwsAccountTestResult {
-		DetailLink: detailLink,
+
+	return &models.AwsAccountTestResult{
+		DetailLink:           detailLink,
 		NoPermissionServices: noPermissionServices,
-		NonPermissionErrors: nonPermissionErrors,
+		NonPermissionErrors:  nonPermissionErrors,
 	}
 }
 

--- a/logicmonitor/schemata/aws_external_id_schema.go
+++ b/logicmonitor/schemata/aws_external_id_schema.go
@@ -1,24 +1,23 @@
 package schemata
 
 import (
-	"strconv"
-	"time"
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strconv"
+	"terraform-provider-logicmonitor/models"
+	"time"
 )
 
 func AwsExternalIDSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"created_at": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"external_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -44,9 +43,9 @@ func AwsExternalIDModel(d map[string]interface{}) *models.AwsExternalID {
 	// assume that the incoming map only contains the relevant resource data
 	createdAt := d["created_at"].(string)
 	externalID := d["external_id"].(string)
-	
-	return &models.AwsExternalID {
-		CreatedAt: createdAt,
+
+	return &models.AwsExternalID{
+		CreatedAt:  createdAt,
 		ExternalID: externalID,
 	}
 }

--- a/logicmonitor/schemata/azure_account_test_result_schema.go
+++ b/logicmonitor/schemata/azure_account_test_result_schema.go
@@ -1,8 +1,8 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func AzureAccountTestResultSchema() map[string]*schema.Schema {
@@ -14,7 +14,7 @@ func AzureAccountTestResultSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"no_permission_services": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -22,7 +22,6 @@ func AzureAccountTestResultSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -40,12 +39,10 @@ func SetAzureAccountTestResultSubResourceData(m []*models.AzureAccountTestResult
 
 func AzureAccountTestResultModel(d map[string]interface{}) *models.AzureAccountTestResult {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.AzureAccountTestResult {
-	}
+
+	return &models.AzureAccountTestResult{}
 }
 
 func GetAzureAccountTestResultPropertyFields() (t []string) {
-	return []string{
-	}
+	return []string{}
 }

--- a/logicmonitor/schemata/chain_schema.go
+++ b/logicmonitor/schemata/chain_schema.go
@@ -1,37 +1,36 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func ChainSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"period": {
-			Type: schema.TypeList, //GoType: Period 
-            Elem: &schema.Resource{
+			Type: schema.TypeList, //GoType: Period
+			Elem: &schema.Resource{
 				Schema: PeriodSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"stages": {
-			Type: schema.TypeList, //GoType: [][]*Recipient 
+			Type: schema.TypeList, //GoType: [][]*Recipient
 			Elem: &schema.Schema{
 				Type: schema.TypeList,
 				Elem: &schema.Resource{Schema: RecipientSchema()},
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Required: true,
+			Required:   true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -40,7 +39,7 @@ func SetChainSubResourceData(m []*models.Chain) (d []*map[string]interface{}) {
 		if chain != nil {
 			properties := make(map[string]interface{})
 			properties["period"] = SetPeriodSubResourceData([]*models.Period{chain.Period})
-            properties["stages"] = SetRecipientSubResourceData(chain.Stages[0])
+			properties["stages"] = SetRecipientSubResourceData(chain.Stages[0])
 			properties["type"] = chain.Type
 			d = append(d, &properties)
 		}
@@ -57,11 +56,11 @@ func ChainModel(d map[string]interface{}) *models.Chain {
 	}
 	stages := utils.GetRecipient(d["stages"].([]interface{}))
 	typeVar := d["type"].(string)
-	
-	return &models.Chain {
+
+	return &models.Chain{
 		Period: period,
 		Stages: stages,
-		Type: &typeVar,
+		Type:   &typeVar,
 	}
 }
 

--- a/logicmonitor/schemata/cloud_account_extra_schema.go
+++ b/logicmonitor/schemata/cloud_account_extra_schema.go
@@ -1,8 +1,8 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CloudAccountExtraSchema() map[string]*schema.Schema {
@@ -14,7 +14,7 @@ func CloudAccountExtraSchema() map[string]*schema.Schema {
 			},
 			Required: true,
 		},
-		
+
 		"default": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -22,7 +22,7 @@ func CloudAccountExtraSchema() map[string]*schema.Schema {
 			},
 			Required: true,
 		},
-		
+
 		"devices": {
 			Type: schema.TypeList, //GoType: CloudDevice
 			Elem: &schema.Resource{
@@ -30,7 +30,7 @@ func CloudAccountExtraSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"services": {
 			Type: schema.TypeList, //GoType: CloudServices
 			Elem: &schema.Resource{
@@ -38,7 +38,6 @@ func CloudAccountExtraSchema() map[string]*schema.Schema {
 			},
 			Required: true,
 		},
-		
 	}
 }
 
@@ -73,10 +72,10 @@ func CloudAccountExtraModel(d map[string]interface{}) *models.CloudAccountExtra 
 	if len(servicesList) > 0 { // len(nil) = 0
 		services = CloudServicesModel(servicesList[0].(map[string]interface{}))
 	}
-	
-	return &models.CloudAccountExtra {
-		Account: account,
-		Default: defaultVar,
+
+	return &models.CloudAccountExtra{
+		Account:  account,
+		Default:  defaultVar,
 		Services: services,
 	}
 }

--- a/logicmonitor/schemata/cloud_account_schema.go
+++ b/logicmonitor/schemata/cloud_account_schema.go
@@ -1,82 +1,81 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CloudAccountSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"account_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"assumed_role_arn": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"billing_bucket_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"billing_path_prefix": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"client_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"country": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"external_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"schedule": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"secret_key": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"subscription_ids": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"tenant_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -116,18 +115,18 @@ func CloudAccountModel(d map[string]interface{}) *models.CloudAccount {
 	secretKey := d["secret_key"].(string)
 	subscriptionIds := d["subscription_ids"].(string)
 	tenantID := d["tenant_id"].(string)
-	
-	return &models.CloudAccount {
-		AccountID: accountID,
-		AssumedRoleArn: assumedRoleArn,
-		ClientID: clientID,
+
+	return &models.CloudAccount{
+		AccountID:            accountID,
+		AssumedRoleArn:       assumedRoleArn,
+		ClientID:             clientID,
 		CollectorDescription: collectorDescription,
-		Country: country,
-		ExternalID: externalID,
-		Schedule: schedule,
-		SecretKey: secretKey,
-		SubscriptionIds: subscriptionIds,
-		TenantID: tenantID,
+		Country:              country,
+		ExternalID:           externalID,
+		Schedule:             schedule,
+		SecretKey:            secretKey,
+		SubscriptionIds:      subscriptionIds,
+		TenantID:             tenantID,
 	}
 }
 

--- a/logicmonitor/schemata/cloud_collector_config_schema.go
+++ b/logicmonitor/schemata/cloud_collector_config_schema.go
@@ -1,37 +1,36 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CloudCollectorConfigSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"applies_to": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"auto_balanced_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"priority": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"use_public_ip": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -57,13 +56,13 @@ func CloudCollectorConfigModel(d map[string]interface{}) *models.CloudCollectorC
 	collectorID := int32(d["collector_id"].(int))
 	priority := int32(d["priority"].(int))
 	usePublicIP := d["use_public_ip"].(bool)
-	
-	return &models.CloudCollectorConfig {
-		AppliesTo: &appliesTo,
+
+	return &models.CloudCollectorConfig{
+		AppliesTo:                    &appliesTo,
 		AutoBalancedCollectorGroupID: autoBalancedCollectorGroupID,
-		CollectorID: &collectorID,
-		Priority: &priority,
-		UsePublicIP: usePublicIP,
+		CollectorID:                  &collectorID,
+		Priority:                     &priority,
+		UsePublicIP:                  usePublicIP,
 	}
 }
 

--- a/logicmonitor/schemata/cloud_device_schema.go
+++ b/logicmonitor/schemata/cloud_device_schema.go
@@ -1,25 +1,24 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CloudDeviceSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"device_type": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"required_props": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -39,9 +38,9 @@ func CloudDeviceModel(d map[string]interface{}) *models.CloudDevice {
 	// assume that the incoming map only contains the relevant resource data
 	deviceType := int32(d["device_type"].(int))
 	requiredProps := utils.ConvertSetToStringSlice(d["required_props"].(*schema.Set))
-	
-	return &models.CloudDevice {
-		DeviceType: &deviceType,
+
+	return &models.CloudDevice{
+		DeviceType:    &deviceType,
 		RequiredProps: requiredProps,
 	}
 }

--- a/logicmonitor/schemata/cloud_normal_collector_config_schema.go
+++ b/logicmonitor/schemata/cloud_normal_collector_config_schema.go
@@ -3,25 +3,25 @@ package schemata
 import (
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CloudNormalCollectorConfigSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"collectors": {
-			Type: schema.TypeList, //GoType: []*CloudCollectorConfig 
+			Type: schema.TypeList, //GoType: []*CloudCollectorConfig
 			Elem: &schema.Resource{
 				Schema: CloudCollectorConfigSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
-		"enabled": {
-			Type: schema.TypeBool,
+
+		"enable": {
+			Type:     schema.TypeBool,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -30,7 +30,12 @@ func SetCloudNormalCollectorConfigSubResourceData(m []*models.CloudNormalCollect
 		if cloudNormalCollectorConfig != nil {
 			properties := make(map[string]interface{})
 			properties["collectors"] = SetCloudCollectorConfigSubResourceData(cloudNormalCollectorConfig.Collectors)
-			properties["enabled"] = cloudNormalCollectorConfig.Enabled
+			// Dereference the pointer - default to false if nil (should not happen with corrected JSON tag)
+			enable := false
+			if cloudNormalCollectorConfig.Enable != nil {
+				enable = *cloudNormalCollectorConfig.Enable
+			}
+			properties["enable"] = enable
 			d = append(d, &properties)
 		}
 	}
@@ -40,17 +45,17 @@ func SetCloudNormalCollectorConfigSubResourceData(m []*models.CloudNormalCollect
 func CloudNormalCollectorConfigModel(d map[string]interface{}) *models.CloudNormalCollectorConfig {
 	// assume that the incoming map only contains the relevant resource data
 	collectors := utils.GetCloudCollectorConfigs(d["collectors"].([]interface{}))
-	enabled := d["enabled"].(bool)
-	
-	return &models.CloudNormalCollectorConfig {
+	enable := d["enable"].(bool)
+
+	return &models.CloudNormalCollectorConfig{
 		Collectors: collectors,
-		Enabled: &enabled,
+		Enable:     &enable,
 	}
 }
 
 func GetCloudNormalCollectorConfigPropertyFields() (t []string) {
 	return []string{
 		"collectors",
-		"enabled",
+		"enable",
 	}
 }

--- a/logicmonitor/schemata/cloud_service_settings_schema.go
+++ b/logicmonitor/schemata/cloud_service_settings_schema.go
@@ -1,59 +1,64 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CloudServiceSettingsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"custom_n_s_p_schedule": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"dead_operation": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_display_name_template": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_stop_terminate_host_monitor": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"disable_terminated_host_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
+		"is_enhanced_monitoring_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+
 		"monitoring_region_infos": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"monitoring_regions": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"name_filter": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"normal_collector_config": {
 			Type: schema.TypeList, //GoType: CloudNormalCollectorConfig
 			Elem: &schema.Resource{
@@ -61,26 +66,25 @@ func CloudServiceSettingsSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"select_all": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"tags": {
-			Type: schema.TypeList, //GoType: []*CloudTagFilter 
+			Type: schema.TypeList, //GoType: []*CloudTagFilter
 			Elem: &schema.Resource{
 				Schema: CloudTagFilterSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"use_default": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -93,6 +97,7 @@ func SetCloudServiceSettingsSubResourceData(m []*models.CloudServiceSettings) (d
 			properties["device_display_name_template"] = cloudServiceSettings.DeviceDisplayNameTemplate
 			properties["disable_stop_terminate_host_monitor"] = cloudServiceSettings.DisableStopTerminateHostMonitor
 			properties["disable_terminated_host_alerting"] = cloudServiceSettings.DisableTerminatedHostAlerting
+			properties["is_enhanced_monitoring_enabled"] = cloudServiceSettings.IsEnhancedMonitoringEnabled
 			properties["monitoring_region_infos"] = cloudServiceSettings.MonitoringRegionInfos
 			properties["monitoring_regions"] = cloudServiceSettings.MonitoringRegions
 			properties["name_filter"] = cloudServiceSettings.NameFilter
@@ -113,6 +118,7 @@ func CloudServiceSettingsModel(d map[string]interface{}) *models.CloudServiceSet
 	deviceDisplayNameTemplate := d["device_display_name_template"].(string)
 	disableStopTerminateHostMonitor := d["disable_stop_terminate_host_monitor"].(bool)
 	disableTerminatedHostAlerting := d["disable_terminated_host_alerting"].(bool)
+	isEnhancedMonitoringEnabled := d["is_enhanced_monitoring_enabled"].(bool)
 	monitoringRegionInfos := utils.ConvertSetToStringSlice(d["monitoring_region_infos"].(*schema.Set))
 	monitoringRegions := utils.ConvertSetToStringSlice(d["monitoring_regions"].(*schema.Set))
 	nameFilter := utils.ConvertSetToStringSlice(d["name_filter"].(*schema.Set))
@@ -124,20 +130,21 @@ func CloudServiceSettingsModel(d map[string]interface{}) *models.CloudServiceSet
 	selectAll := d["select_all"].(bool)
 	tags := utils.GetCloudTagFilters(d["tags"].([]interface{}))
 	useDefault := d["use_default"].(bool)
-	
-	return &models.CloudServiceSettings {
-		CustomNSPSchedule: customNSPSchedule,
-		DeadOperation: deadOperation,
-		DeviceDisplayNameTemplate: deviceDisplayNameTemplate,
+
+	return &models.CloudServiceSettings{
+		CustomNSPSchedule:               customNSPSchedule,
+		DeadOperation:                   deadOperation,
+		DeviceDisplayNameTemplate:       deviceDisplayNameTemplate,
 		DisableStopTerminateHostMonitor: disableStopTerminateHostMonitor,
-		DisableTerminatedHostAlerting: disableTerminatedHostAlerting,
-		MonitoringRegionInfos: monitoringRegionInfos,
-		MonitoringRegions: monitoringRegions,
-		NameFilter: nameFilter,
-		NormalCollectorConfig: normalCollectorConfig,
-		SelectAll: selectAll,
-		Tags: tags,
-		UseDefault: &useDefault,
+		DisableTerminatedHostAlerting:   disableTerminatedHostAlerting,
+		IsEnhancedMonitoringEnabled:     isEnhancedMonitoringEnabled,
+		MonitoringRegionInfos:           monitoringRegionInfos,
+		MonitoringRegions:               monitoringRegions,
+		NameFilter:                      nameFilter,
+		NormalCollectorConfig:           normalCollectorConfig,
+		SelectAll:                       selectAll,
+		Tags:                            tags,
+		UseDefault:                      &useDefault,
 	}
 }
 
@@ -148,6 +155,7 @@ func GetCloudServiceSettingsPropertyFields() (t []string) {
 		"device_display_name_template",
 		"disable_stop_terminate_host_monitor",
 		"disable_terminated_host_alerting",
+		"is_enhanced_monitoring_enabled",
 		"monitoring_region_infos",
 		"monitoring_regions",
 		"name_filter",

--- a/logicmonitor/schemata/cloud_services_schema.go
+++ b/logicmonitor/schemata/cloud_services_schema.go
@@ -8,7 +8,47 @@ import (
 
 func CloudServicesSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"a_c_m": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"a_l_a_r_m_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"a_n_a_l_y_s_i_s_s_e_r_v_i_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"api_g_a_t_e_w_a_y": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"api_g_a_t_e_w_a_y_v2": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -48,6 +88,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"a_p_p_s_e_r_v_i_c_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -57,6 +105,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 		},
 
 		"a_p_p_s_e_r_v_i_c_e_p_l_a_n": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -96,7 +152,55 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"b_a_c_k_u_p": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"b_a_c_k_u_p_v_a_u_l_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"b_a_t_c_h": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"b_a_t_c_h_a_c_c_o_u_n_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"b_e_d_r_o_c_k": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -112,6 +216,22 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"b_o_t_s_e_r_v_i_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_d_n_p_r_o_f_i_l_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"c_l_o_u_d_f_r_o_n_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -120,7 +240,47 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"c_l_i_e_n_t_v_p_n": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"c_l_o_u_d_s_e_a_r_c_h": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_l_o_u_d_t_r_a_i_l": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_l_o_u_d_w_a_t_c_h_e_v_e_n_t_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_l_o_u_d_w_a_t_c_h_l_o_g_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_l_o_u_d_w_a_t_c_h_s_y_n_t_h_e_t_i_c_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -160,6 +320,30 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"c_o_n_t_a_i_n_e_r_a_p_p_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"c_o_s_m_o_s_d_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -176,7 +360,63 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"d_a_t_a_l_a_k_e_s_t_o_r_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"d_a_t_a_b_r_i_c_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"d_b_c_l_u_s_t_e_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"d_e_t_e_c_t_i_v_e_g_r_a_p_h": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"d_i_r_e_c_t_c_o_n_n_e_c_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"d_i_s_k_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -232,6 +472,22 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"e_c_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"e_l_a_s_t_i_c_ip": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"e_c_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -241,6 +497,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 		},
 
 		"e_f_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"e_k_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -304,6 +568,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"e_v_e_n_t_g_r_i_d": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"e_v_e_n_t_h_u_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -360,6 +632,30 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"f_u_n_c_t_i_o_n": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"g_a_t_e_w_a_y_e_l_b": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"g_l_o_b_a_l_n_e_t_w_o_r_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"g_l_u_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -368,7 +664,63 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"h_e_a_l_t_h_c_h_e_c_k": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"h_d_i_n_s_i_g_h_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"h_o_s_t_e_d_z_o_n_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"i_a_m_r_o_l_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"i_n_t_e_r_n_e_t_g_a_t_e_w_a_y": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"i_o_t_h_u_b": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"k_e_y_v_a_u_l_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"k_m_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -393,6 +745,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 		},
 
 		"l_a_m_b_d_a": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"l_i_g_h_t_s_a_i_l": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -472,6 +832,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"m_l_w_o_r_k_s_p_a_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"m_q": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -496,7 +864,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"m_a_r_i_a_d_b": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"m_y_sql": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"m_y_sql_f_l_e_x_i_b_l_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -520,7 +904,55 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"n_e_t_w_o_r_k_f_i_r_e_w_a_l_l": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"n_a_t_g_a_t_e_w_a_y_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"n_e_t_a_p_p_p_o_o_l_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"n_l_b_t_a_r_g_e_t_g_r_o_u_p": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"o_p_e_n_a_i_s_e_r_v_i_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -544,6 +976,30 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"p_o_s_t_g_r_e_sql_c_i_t_u_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"p_o_w_e_r_b_i_e_m_b_e_d_d_e_d": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"p_u_b_l_i_c_ip": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -552,7 +1008,55 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"q_b_u_s_i_n_e_s_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"q_u_o_t_a": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"q_u_e_u_e_s_t_o_r_a_g_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"q_u_i_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"q_u_i_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -576,6 +1080,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -592,6 +1104,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"r_e_d_s_h_i_f_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -600,7 +1120,31 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"r_o_u_t_e53": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"r_e_l_a_y_n_a_m_e_s_p_a_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -640,7 +1184,31 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"s_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"s_i_g_n_a_l_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"s_i_t_e2_s_i_t_e_v_p_n": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -704,6 +1272,22 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"s_t_o_r_a_g_e_g_a_t_e_w_a_y": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"s_t_r_e_a_m_a_n_a_l_y_t_i_c_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"s_w_f_a_c_t_i_v_i_t_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -744,6 +1328,14 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"t_r_a_n_s_f_e_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"t_r_a_n_s_i_t_g_a_t_e_w_a_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -752,7 +1344,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"v_i_r_t_u_a_l_d_e_s_k_t_o_p": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"v_i_r_t_u_a_l_h_u_b_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -792,7 +1400,47 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 
+		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"v_p_c": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"v_p_c_e_n_d_p_o_i_n_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"v_p_c_p_e_e_r_i_n_g": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
 		"v_p_n": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+
+		"v_p_n_g_a_t_e_w_a_y_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
@@ -822,36 +1470,69 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 	for _, cloudServices := range m {
 		if cloudServices != nil {
 			properties := make(map[string]interface{})
+			properties["a_c_m"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ACM})
+			properties["a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.AKSMANAGEDCLUSTER})
+			properties["a_l_a_r_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ALARMS})
+			properties["a_n_a_l_y_s_i_s_s_e_r_v_i_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ANALYSISSERVICE})
 			properties["api_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APIGATEWAY})
+			properties["api_g_a_t_e_w_a_y_v2"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APIGATEWAYV2})
 			properties["api_m_a_n_a_g_e_m_e_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APIMANAGEMENT})
 			properties["a_p_p_l_i_c_a_t_i_o_n_e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONELB})
 			properties["a_p_p_l_i_c_a_t_i_o_n_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONGATEWAY})
 			properties["a_p_p_l_i_c_a_t_i_o_n_i_n_s_i_g_h_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONINSIGHTS})
+			properties["a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONMIGRATIONSERVICE})
 			properties["a_p_p_s_e_r_v_i_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSERVICE})
 			properties["a_p_p_s_e_r_v_i_c_e_p_l_a_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSERVICEPLAN})
+			properties["a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSERVICEENVIRONMENT})
 			properties["a_p_p_s_t_r_e_a_m"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSTREAM})
 			properties["a_t_h_e_n_a"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ATHENA})
 			properties["a_u_t_o_m_a_t_i_o_n_a_c_c_o_u_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.AUTOMATIONACCOUNT})
 			properties["a_u_t_o_s_c_a_l_i_n_g"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.AUTOSCALING})
+			properties["b_a_c_k_u_p"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUP})
 			properties["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUPPROTECTEDITEMS})
+			properties["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUPPROTECTEDRESOURCE})
+			properties["b_a_c_k_u_p_v_a_u_l_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUPVAULT})
+			properties["b_a_t_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BATCH})
+			properties["b_a_t_c_h_a_c_c_o_u_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BATCHACCOUNT})
+			properties["b_e_d_r_o_c_k"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BEDROCK})
 			properties["b_l_o_b_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BLOBSTORAGE})
+			properties["b_o_t_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BOTSERVICES})
+			properties["c_d_n_p_r_o_f_i_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CDNPROFILE})
+			properties["c_l_i_e_n_t_v_p_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLIENTVPN})
 			properties["c_l_o_u_d_f_r_o_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDFRONT})
 			properties["c_l_o_u_d_s_e_a_r_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDSEARCH})
+			properties["c_l_o_u_d_t_r_a_i_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDTRAIL})
+			properties["c_l_o_u_d_w_a_t_c_h_e_v_e_n_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDWATCHEVENTS})
+			properties["c_l_o_u_d_w_a_t_c_h_l_o_g_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDWATCHLOGS})
+			properties["c_l_o_u_d_w_a_t_c_h_s_y_n_t_h_e_t_i_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDWATCHSYNTHETICS})
 			properties["c_o_d_e_b_ui_l_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CODEBUILD})
 			properties["c_o_g_n_i_t_i_v_e_s_e_a_r_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COGNITIVESEARCH})
 			properties["c_o_g_n_i_t_i_v_e_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COGNITIVESERVICES})
 			properties["c_o_g_n_i_t_o"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COGNITO})
+			properties["c_o_n_t_a_i_n_e_r_a_p_p_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CONTAINERAPPS})
+			properties["c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CONTAINERINSTANCE})
+			properties["c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CONTAINERREGISTRY})
 			properties["c_o_s_m_o_s_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COSMOSDB})
 			properties["d_a_t_a_f_a_c_t_o_r_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATAFACTORY})
+			properties["d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATALAKEANALYTICS})
+			properties["d_a_t_a_l_a_k_e_s_t_o_r_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATALAKESTORE})
+			properties["d_a_t_a_b_r_i_c_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATABRICKS})
+			properties["d_b_c_l_u_s_t_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DBCLUSTER})
+			properties["d_e_t_e_c_t_i_v_e_g_r_a_p_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DETECTIVEGRAPH})
 			properties["d_i_r_e_c_t_c_o_n_n_e_c_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DIRECTCONNECT})
+			properties["d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DIRECTCONNECTVIRTUALINTERFACE})
+			properties["d_i_s_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DISKS})
 			properties["d_m_s_r_e_p_l_i_c_a_t_i_o_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DMSREPLICATION})
 			properties["d_m_s_r_e_p_l_i_c_a_t_i_o_n_t_a_s_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DMSREPLICATIONTASKS})
 			properties["d_o_c_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DOCDB})
 			properties["d_y_n_a_m_o_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DYNAMODB})
 			properties["e_b_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EBS})
 			properties["e_c2"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EC2})
+			properties["e_c_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ECR})
 			properties["e_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ECS})
+			properties["e_l_a_s_t_i_c_ip"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICIP})
 			properties["e_f_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EFS})
+			properties["e_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EKS})
 			properties["e_l_a_s_t_i_c_a_c_h_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICACHE})
 			properties["e_l_a_s_t_i_c_b_e_a_n_s_t_a_l_k"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICBEANSTALK})
 			properties["e_l_a_s_t_i_c_s_e_a_r_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICSEARCH})
@@ -859,6 +1540,7 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELB})
 			properties["e_m_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EMR})
 			properties["e_v_e_n_t_b_r_id_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EVENTBRIDGE})
+			properties["e_v_e_n_t_g_r_i_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EVENTGRID})
 			properties["e_v_e_n_t_h_u_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EVENTHUB})
 			properties["e_x_p_r_e_s_s_r_o_u_t_e_c_i_r_c_ui_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EXPRESSROUTECIRCUIT})
 			properties["f_i_l_e_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FILESTORAGE})
@@ -866,11 +1548,22 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["f_i_r_e_w_a_l_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FIREWALL})
 			properties["f_r_o_n_t_d_o_o_r_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FRONTDOORS})
 			properties["f_s_x"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FSX})
+			properties["f_u_n_c_t_i_o_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FUNCTION})
+			properties["g_a_t_e_w_a_y_e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.GATEWAYELB})
+			properties["g_l_o_b_a_l_n_e_t_w_o_r_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.GLOBALNETWORKS})
 			properties["g_l_u_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.GLUE})
+			properties["h_e_a_l_t_h_c_h_e_c_k"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.HEALTHCHECK})
+			properties["h_d_i_n_s_i_g_h_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.HDINSIGHT})
+			properties["h_o_s_t_e_d_z_o_n_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.HOSTEDZONE})
+			properties["i_a_m_r_o_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.IAMROLE})
+			properties["i_n_t_e_r_n_e_t_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.INTERNETGATEWAY})
+			properties["i_o_t_h_u_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.IOTHUB})
 			properties["k_e_y_v_a_u_l_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KEYVAULT})
+			properties["k_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KMS})
 			properties["k_i_n_e_s_i_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KINESIS})
 			properties["k_i_n_e_s_i_s_v_id_e_o"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KINESISVIDEO})
 			properties["l_a_m_b_d_a"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LAMBDA})
+			properties["l_i_g_h_t_s_a_i_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LIGHTSAIL})
 			properties["l_o_a_d_b_a_l_a_n_c_e_r_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LOADBALANCERS})
 			properties["l_o_g_a_n_a_l_y_t_i_c_s_w_o_r_k_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LOGANALYTICSWORKSPACES})
 			properties["l_o_g_i_c_a_p_p_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LOGICAPPS})
@@ -880,28 +1573,54 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["m_e_d_i_a_p_a_c_k_a_g_e_v_o_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIAPACKAGEVOD})
 			properties["m_e_d_i_a_s_t_o_r_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIASTORE})
 			properties["m_e_d_i_a_t_a_i_l_o_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIATAILOR})
+			properties["m_l_w_o_r_k_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MLWORKSPACES})
 			properties["m_q"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MQ})
+			properties["m_a_r_i_a_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MARIADB})
 			properties["m_s_k_b_r_o_k_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MSKBROKER})
 			properties["m_s_k_c_l_u_s_t_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MSKCLUSTER})
 			properties["m_y_sql"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MYSQL})
+			properties["m_y_sql_f_l_e_x_i_b_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MYSQLFLEXIBLE})
 			properties["n_a_t_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NATGATEWAY})
 			properties["n_e_t_w_o_r_k_e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETWORKELB})
+			properties["n_e_t_w_o_r_k_f_i_r_e_w_a_l_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETWORKFIREWALL})
+			properties["n_a_t_g_a_t_e_w_a_y_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NATGATEWAYS})
+			properties["n_e_t_a_p_p_p_o_o_l_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETAPPPOOLS})
 			properties["n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETWORKINTERFACE})
+			properties["n_l_b_t_a_r_g_e_t_g_r_o_u_p"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NLBTARGETGROUP})
+			properties["n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NOTIFICATIONHUBS})
+			properties["o_p_e_n_a_i_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.OPENAISERVICES})
 			properties["o_p_s_w_o_r_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.OPSWORKS})
 			properties["p_o_s_t_g_r_e_sql"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POSTGRESQL})
+			properties["p_o_s_t_g_r_e_sql_c_i_t_u_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POSTGRESQLCITUS})
+			properties["p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POSTGRESQLFLEXIBLE})
+			properties["p_o_w_e_r_b_i_e_m_b_e_d_d_e_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POWERBIEMBEDDED})
 			properties["p_u_b_l_i_c_ip"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.PUBLICIP})
+			properties["p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.PRIVATELINKENDPOINTS})
+			properties["p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.PRIVATELINKSERVICES})
+			properties["q_b_u_s_i_n_e_s_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QBUSINESS})
+			properties["q_u_o_t_a"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUOTA})
 			properties["q_u_e_u_e_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUEUESTORAGE})
+			properties["q_u_i_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUICKSIGHTDASHBOARDS})
+			properties["q_u_i_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUICKSIGHTDATASETS})
 			properties["r_d_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RDS})
 			properties["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RECOVERYPROTECTEDITEM})
+			properties["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RECOVERYPROTECTEDITEMS})
 			properties["r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RECOVERYSERVICES})
 			properties["r_e_d_i_s_c_a_c_h_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDISCACHE})
+			properties["r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDISCACHEENTERPRISE})
 			properties["r_e_d_s_h_i_f_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDSHIFT})
+			properties["r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDSHIFTSERVERLESS})
+			properties["r_e_l_a_y_n_a_m_e_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RELAYNAMESPACES})
 			properties["r_o_u_t_e53"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ROUTE53})
+			properties["r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ROUTE53HOSTEDZONE})
 			properties["r_o_u_t_e53_r_e_s_o_l_v_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ROUTE53RESOLVER})
 			properties["s3"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.S3})
 			properties["s_a_g_e_m_a_k_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SAGEMAKER})
 			properties["s_e_r_v_i_c_e_b_u_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SERVICEBUS})
+			properties["s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SERVICEFABRICMESH})
 			properties["s_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SES})
+			properties["s_i_g_n_a_l_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SIGNALR})
+			properties["s_i_t_e2_s_i_t_e_v_p_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SITE2SITEVPN})
 			properties["s_n_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SNS})
 			properties["sql_d_a_t_a_b_a_s_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SQLDATABASE})
 			properties["sql_e_l_a_s_t_i_c_p_o_o_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SQLELASTICPOOL})
@@ -909,18 +1628,28 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["s_q_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SQS})
 			properties["s_t_e_p_f_u_n_c_t_i_o_n_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STEPFUNCTIONS})
 			properties["s_t_o_r_a_g_e_a_c_c_o_u_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STORAGEACCOUNT})
+			properties["s_t_o_r_a_g_e_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STORAGEGATEWAY})
+			properties["s_t_r_e_a_m_a_n_a_l_y_t_i_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STREAMANALYTICS})
 			properties["s_w_f_a_c_t_i_v_i_t_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SWFACTIVITY})
 			properties["s_w_f_w_o_r_k_f_l_o_w"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SWFWORKFLOW})
 			properties["s_y_n_a_p_s_e_w_o_r_k_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SYNAPSEWORKSPACES})
 			properties["t_a_b_l_e_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TABLESTORAGE})
 			properties["t_r_a_f_f_i_c_m_a_n_a_g_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRAFFICMANAGER})
+			properties["t_r_a_n_s_f_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRANSFER})
 			properties["t_r_a_n_s_i_t_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRANSITGATEWAY})
+			properties["t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRANSITGATEWAYATTACHMENT})
 			properties["v_i_r_t_u_a_l_d_e_s_k_t_o_p"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALDESKTOP})
+			properties["v_i_r_t_u_a_l_h_u_b_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALHUBS})
 			properties["v_i_r_t_u_a_l_m_a_c_h_i_n_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALMACHINE})
 			properties["v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALMACHINESCALESET})
 			properties["v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t_vm"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALMACHINESCALESETVM})
 			properties["v_i_r_t_u_a_l_n_e_t_w_o_r_k_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALNETWORKGATEWAY})
+			properties["v_i_r_t_u_a_l_n_e_t_w_o_r_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALNETWORKS})
+			properties["v_p_c"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPC})
+			properties["v_p_c_e_n_d_p_o_i_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPCENDPOINT})
+			properties["v_p_c_p_e_e_r_i_n_g"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPCPEERING})
 			properties["v_p_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPN})
+			properties["v_p_n_g_a_t_e_w_a_y_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPNGATEWAYS})
 			properties["w_o_r_k_s_p_a_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.WORKSPACE})
 			properties["w_o_r_k_s_p_a_c_e_d_i_r_e_c_t_o_r_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.WORKSPACEDIRECTORY})
 			d = append(d, &properties)
@@ -931,10 +1660,35 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 
 func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	// assume that the incoming map only contains the relevant resource data
+	var aCM *models.CloudServiceSettings = nil
+	ACMList := d["a_c_m"].([]interface{})
+	if len(ACMList) > 0 { // len(nil) = 0
+		aCM = CloudServiceSettingsModel(ACMList[0].(map[string]interface{}))
+	}
+	var aKSMANAGEDCLUSTER *models.CloudServiceSettings = nil
+	AKSMANAGEDCLUSTERList := d["a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r"].([]interface{})
+	if len(AKSMANAGEDCLUSTERList) > 0 { // len(nil) = 0
+		aKSMANAGEDCLUSTER = CloudServiceSettingsModel(AKSMANAGEDCLUSTERList[0].(map[string]interface{}))
+	}
+	var aLARMS *models.CloudServiceSettings = nil
+	ALARMSList := d["a_l_a_r_m_s"].([]interface{})
+	if len(ALARMSList) > 0 { // len(nil) = 0
+		aLARMS = CloudServiceSettingsModel(ALARMSList[0].(map[string]interface{}))
+	}
+	var aNALYSISSERVICE *models.CloudServiceSettings = nil
+	ANALYSISSERVICEList := d["a_n_a_l_y_s_i_s_s_e_r_v_i_c_e"].([]interface{})
+	if len(ANALYSISSERVICEList) > 0 { // len(nil) = 0
+		aNALYSISSERVICE = CloudServiceSettingsModel(ANALYSISSERVICEList[0].(map[string]interface{}))
+	}
 	var aPIGATEWAY *models.CloudServiceSettings = nil
 	APIGATEWAYList := d["api_g_a_t_e_w_a_y"].([]interface{})
 	if len(APIGATEWAYList) > 0 { // len(nil) = 0
 		aPIGATEWAY = CloudServiceSettingsModel(APIGATEWAYList[0].(map[string]interface{}))
+	}
+	var aPIGATEWAYV2 *models.CloudServiceSettings = nil
+	APIGATEWAYV2List := d["api_g_a_t_e_w_a_y_v2"].([]interface{})
+	if len(APIGATEWAYV2List) > 0 { // len(nil) = 0
+		aPIGATEWAYV2 = CloudServiceSettingsModel(APIGATEWAYV2List[0].(map[string]interface{}))
 	}
 	var aPIMANAGEMENT *models.CloudServiceSettings = nil
 	APIMANAGEMENTList := d["api_m_a_n_a_g_e_m_e_n_t"].([]interface{})
@@ -956,6 +1710,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(APPLICATIONINSIGHTSList) > 0 { // len(nil) = 0
 		aPPLICATIONINSIGHTS = CloudServiceSettingsModel(APPLICATIONINSIGHTSList[0].(map[string]interface{}))
 	}
+	var aPPLICATIONMIGRATIONSERVICE *models.CloudServiceSettings = nil
+	APPLICATIONMIGRATIONSERVICEList := d["a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e"].([]interface{})
+	if len(APPLICATIONMIGRATIONSERVICEList) > 0 { // len(nil) = 0
+		aPPLICATIONMIGRATIONSERVICE = CloudServiceSettingsModel(APPLICATIONMIGRATIONSERVICEList[0].(map[string]interface{}))
+	}
 	var aPPSERVICE *models.CloudServiceSettings = nil
 	APPSERVICEList := d["a_p_p_s_e_r_v_i_c_e"].([]interface{})
 	if len(APPSERVICEList) > 0 { // len(nil) = 0
@@ -965,6 +1724,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	APPSERVICEPLANList := d["a_p_p_s_e_r_v_i_c_e_p_l_a_n"].([]interface{})
 	if len(APPSERVICEPLANList) > 0 { // len(nil) = 0
 		aPPSERVICEPLAN = CloudServiceSettingsModel(APPSERVICEPLANList[0].(map[string]interface{}))
+	}
+	var aPPSERVICEENVIRONMENT *models.CloudServiceSettings = nil
+	APPSERVICEENVIRONMENTList := d["a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t"].([]interface{})
+	if len(APPSERVICEENVIRONMENTList) > 0 { // len(nil) = 0
+		aPPSERVICEENVIRONMENT = CloudServiceSettingsModel(APPSERVICEENVIRONMENTList[0].(map[string]interface{}))
 	}
 	var aPPSTREAM *models.CloudServiceSettings = nil
 	APPSTREAMList := d["a_p_p_s_t_r_e_a_m"].([]interface{})
@@ -986,15 +1750,60 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(AUTOSCALINGList) > 0 { // len(nil) = 0
 		aUTOSCALING = CloudServiceSettingsModel(AUTOSCALINGList[0].(map[string]interface{}))
 	}
+	var bACKUP *models.CloudServiceSettings = nil
+	BACKUPList := d["b_a_c_k_u_p"].([]interface{})
+	if len(BACKUPList) > 0 { // len(nil) = 0
+		bACKUP = CloudServiceSettingsModel(BACKUPList[0].(map[string]interface{}))
+	}
 	var bACKUPPROTECTEDITEMS *models.CloudServiceSettings = nil
 	BACKUPPROTECTEDITEMSList := d["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s"].([]interface{})
 	if len(BACKUPPROTECTEDITEMSList) > 0 { // len(nil) = 0
 		bACKUPPROTECTEDITEMS = CloudServiceSettingsModel(BACKUPPROTECTEDITEMSList[0].(map[string]interface{}))
 	}
+	var bACKUPPROTECTEDRESOURCE *models.CloudServiceSettings = nil
+	BACKUPPROTECTEDRESOURCEList := d["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e"].([]interface{})
+	if len(BACKUPPROTECTEDRESOURCEList) > 0 { // len(nil) = 0
+		bACKUPPROTECTEDRESOURCE = CloudServiceSettingsModel(BACKUPPROTECTEDRESOURCEList[0].(map[string]interface{}))
+	}
+	var bACKUPVAULT *models.CloudServiceSettings = nil
+	BACKUPVAULTList := d["b_a_c_k_u_p_v_a_u_l_t"].([]interface{})
+	if len(BACKUPVAULTList) > 0 { // len(nil) = 0
+		bACKUPVAULT = CloudServiceSettingsModel(BACKUPVAULTList[0].(map[string]interface{}))
+	}
+	var bATCH *models.CloudServiceSettings = nil
+	BATCHList := d["b_a_t_c_h"].([]interface{})
+	if len(BATCHList) > 0 { // len(nil) = 0
+		bATCH = CloudServiceSettingsModel(BATCHList[0].(map[string]interface{}))
+	}
+	var bATCHACCOUNT *models.CloudServiceSettings = nil
+	BATCHACCOUNTList := d["b_a_t_c_h_a_c_c_o_u_n_t"].([]interface{})
+	if len(BATCHACCOUNTList) > 0 { // len(nil) = 0
+		bATCHACCOUNT = CloudServiceSettingsModel(BATCHACCOUNTList[0].(map[string]interface{}))
+	}
+	var bEDROCK *models.CloudServiceSettings = nil
+	BEDROCKList := d["b_e_d_r_o_c_k"].([]interface{})
+	if len(BEDROCKList) > 0 { // len(nil) = 0
+		bEDROCK = CloudServiceSettingsModel(BEDROCKList[0].(map[string]interface{}))
+	}
 	var bLOBSTORAGE *models.CloudServiceSettings = nil
 	BLOBSTORAGEList := d["b_l_o_b_s_t_o_r_a_g_e"].([]interface{})
 	if len(BLOBSTORAGEList) > 0 { // len(nil) = 0
 		bLOBSTORAGE = CloudServiceSettingsModel(BLOBSTORAGEList[0].(map[string]interface{}))
+	}
+	var bOTSERVICES *models.CloudServiceSettings = nil
+	BOTSERVICESList := d["b_o_t_s_e_r_v_i_c_e_s"].([]interface{})
+	if len(BOTSERVICESList) > 0 { // len(nil) = 0
+		bOTSERVICES = CloudServiceSettingsModel(BOTSERVICESList[0].(map[string]interface{}))
+	}
+	var cDNPROFILE *models.CloudServiceSettings = nil
+	CDNPROFILEList := d["c_d_n_p_r_o_f_i_l_e"].([]interface{})
+	if len(CDNPROFILEList) > 0 { // len(nil) = 0
+		cDNPROFILE = CloudServiceSettingsModel(CDNPROFILEList[0].(map[string]interface{}))
+	}
+	var cLIENTVPN *models.CloudServiceSettings = nil
+	CLIENTVPNList := d["c_l_i_e_n_t_v_p_n"].([]interface{})
+	if len(CLIENTVPNList) > 0 { // len(nil) = 0
+		cLIENTVPN = CloudServiceSettingsModel(CLIENTVPNList[0].(map[string]interface{}))
 	}
 	var cLOUDFRONT *models.CloudServiceSettings = nil
 	CLOUDFRONTList := d["c_l_o_u_d_f_r_o_n_t"].([]interface{})
@@ -1005,6 +1814,26 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	CLOUDSEARCHList := d["c_l_o_u_d_s_e_a_r_c_h"].([]interface{})
 	if len(CLOUDSEARCHList) > 0 { // len(nil) = 0
 		cLOUDSEARCH = CloudServiceSettingsModel(CLOUDSEARCHList[0].(map[string]interface{}))
+	}
+	var cLOUDTRAIL *models.CloudServiceSettings = nil
+	CLOUDTRAILList := d["c_l_o_u_d_t_r_a_i_l"].([]interface{})
+	if len(CLOUDTRAILList) > 0 { // len(nil) = 0
+		cLOUDTRAIL = CloudServiceSettingsModel(CLOUDTRAILList[0].(map[string]interface{}))
+	}
+	var cLOUDWATCHEVENTS *models.CloudServiceSettings = nil
+	CLOUDWATCHEVENTSList := d["c_l_o_u_d_w_a_t_c_h_e_v_e_n_t_s"].([]interface{})
+	if len(CLOUDWATCHEVENTSList) > 0 { // len(nil) = 0
+		cLOUDWATCHEVENTS = CloudServiceSettingsModel(CLOUDWATCHEVENTSList[0].(map[string]interface{}))
+	}
+	var cLOUDWATCHLOGS *models.CloudServiceSettings = nil
+	CLOUDWATCHLOGSList := d["c_l_o_u_d_w_a_t_c_h_l_o_g_s"].([]interface{})
+	if len(CLOUDWATCHLOGSList) > 0 { // len(nil) = 0
+		cLOUDWATCHLOGS = CloudServiceSettingsModel(CLOUDWATCHLOGSList[0].(map[string]interface{}))
+	}
+	var cLOUDWATCHSYNTHETICS *models.CloudServiceSettings = nil
+	CLOUDWATCHSYNTHETICSList := d["c_l_o_u_d_w_a_t_c_h_s_y_n_t_h_e_t_i_c_s"].([]interface{})
+	if len(CLOUDWATCHSYNTHETICSList) > 0 { // len(nil) = 0
+		cLOUDWATCHSYNTHETICS = CloudServiceSettingsModel(CLOUDWATCHSYNTHETICSList[0].(map[string]interface{}))
 	}
 	var cODEBUILD *models.CloudServiceSettings = nil
 	CODEBUILDList := d["c_o_d_e_b_ui_l_d"].([]interface{})
@@ -1027,6 +1856,21 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 		cOGNITO = CloudServiceSettingsModel(COGNITOList[0].(map[string]interface{}))
 	}
 	var cOSMOSDB *models.CloudServiceSettings = nil
+	var cONTAINERAPPS *models.CloudServiceSettings = nil
+	CONTAINERAPPSList := d["c_o_n_t_a_i_n_e_r_a_p_p_s"].([]interface{})
+	if len(CONTAINERAPPSList) > 0 { // len(nil) = 0
+		cONTAINERAPPS = CloudServiceSettingsModel(CONTAINERAPPSList[0].(map[string]interface{}))
+	}
+	var cONTAINERINSTANCE *models.CloudServiceSettings = nil
+	CONTAINERINSTANCEList := d["c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e"].([]interface{})
+	if len(CONTAINERINSTANCEList) > 0 { // len(nil) = 0
+		cONTAINERINSTANCE = CloudServiceSettingsModel(CONTAINERINSTANCEList[0].(map[string]interface{}))
+	}
+	var cONTAINERREGISTRY *models.CloudServiceSettings = nil
+	CONTAINERREGISTRYList := d["c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y"].([]interface{})
+	if len(CONTAINERREGISTRYList) > 0 { // len(nil) = 0
+		cONTAINERREGISTRY = CloudServiceSettingsModel(CONTAINERREGISTRYList[0].(map[string]interface{}))
+	}
 	COSMOSDBList := d["c_o_s_m_o_s_d_b"].([]interface{})
 	if len(COSMOSDBList) > 0 { // len(nil) = 0
 		cOSMOSDB = CloudServiceSettingsModel(COSMOSDBList[0].(map[string]interface{}))
@@ -1036,10 +1880,45 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(DATAFACTORYList) > 0 { // len(nil) = 0
 		dATAFACTORY = CloudServiceSettingsModel(DATAFACTORYList[0].(map[string]interface{}))
 	}
+	var dATALAKEANALYTICS *models.CloudServiceSettings = nil
+	DATALAKEANALYTICSList := d["d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s"].([]interface{})
+	if len(DATALAKEANALYTICSList) > 0 { // len(nil) = 0
+		dATALAKEANALYTICS = CloudServiceSettingsModel(DATALAKEANALYTICSList[0].(map[string]interface{}))
+	}
+	var dATALAKESTORE *models.CloudServiceSettings = nil
+	DATALAKESTOREList := d["d_a_t_a_l_a_k_e_s_t_o_r_e"].([]interface{})
+	if len(DATALAKESTOREList) > 0 { // len(nil) = 0
+		dATALAKESTORE = CloudServiceSettingsModel(DATALAKESTOREList[0].(map[string]interface{}))
+	}
+	var dATABRICKS *models.CloudServiceSettings = nil
+	DATABRICKSList := d["d_a_t_a_b_r_i_c_k_s"].([]interface{})
+	if len(DATABRICKSList) > 0 { // len(nil) = 0
+		dATABRICKS = CloudServiceSettingsModel(DATABRICKSList[0].(map[string]interface{}))
+	}
+	var dBCLUSTER *models.CloudServiceSettings = nil
+	DBCLUSTERList := d["d_b_c_l_u_s_t_e_r"].([]interface{})
+	if len(DBCLUSTERList) > 0 { // len(nil) = 0
+		dBCLUSTER = CloudServiceSettingsModel(DBCLUSTERList[0].(map[string]interface{}))
+	}
+	var dETECTIVEGRAPH *models.CloudServiceSettings = nil
+	DETECTIVEGRAPHList := d["d_e_t_e_c_t_i_v_e_g_r_a_p_h"].([]interface{})
+	if len(DETECTIVEGRAPHList) > 0 { // len(nil) = 0
+		dETECTIVEGRAPH = CloudServiceSettingsModel(DETECTIVEGRAPHList[0].(map[string]interface{}))
+	}
 	var dIRECTCONNECT *models.CloudServiceSettings = nil
 	DIRECTCONNECTList := d["d_i_r_e_c_t_c_o_n_n_e_c_t"].([]interface{})
 	if len(DIRECTCONNECTList) > 0 { // len(nil) = 0
 		dIRECTCONNECT = CloudServiceSettingsModel(DIRECTCONNECTList[0].(map[string]interface{}))
+	}
+	var dIRECTCONNECTVIRTUALINTERFACE *models.CloudServiceSettings = nil
+	DIRECTCONNECTVIRTUALINTERFACEList := d["d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e"].([]interface{})
+	if len(DIRECTCONNECTVIRTUALINTERFACEList) > 0 { // len(nil) = 0
+		dIRECTCONNECTVIRTUALINTERFACE = CloudServiceSettingsModel(DIRECTCONNECTVIRTUALINTERFACEList[0].(map[string]interface{}))
+	}
+	var dISKS *models.CloudServiceSettings = nil
+	DISKSList := d["d_i_s_k_s"].([]interface{})
+	if len(DISKSList) > 0 { // len(nil) = 0
+		dISKS = CloudServiceSettingsModel(DISKSList[0].(map[string]interface{}))
 	}
 	var dMSREPLICATION *models.CloudServiceSettings = nil
 	DMSREPLICATIONList := d["d_m_s_r_e_p_l_i_c_a_t_i_o_n"].([]interface{})
@@ -1071,15 +1950,30 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(EC2List) > 0 { // len(nil) = 0
 		eC2 = CloudServiceSettingsModel(EC2List[0].(map[string]interface{}))
 	}
+	var eCR *models.CloudServiceSettings = nil
+	ECRList := d["e_c_r"].([]interface{})
+	if len(ECRList) > 0 { // len(nil) = 0
+		eCR = CloudServiceSettingsModel(ECRList[0].(map[string]interface{}))
+	}
 	var eCS *models.CloudServiceSettings = nil
 	ECSList := d["e_c_s"].([]interface{})
 	if len(ECSList) > 0 { // len(nil) = 0
 		eCS = CloudServiceSettingsModel(ECSList[0].(map[string]interface{}))
 	}
+	var eLASTICIP *models.CloudServiceSettings = nil
+	ELASTICIPList := d["e_l_a_s_t_i_c_ip"].([]interface{})
+	if len(ELASTICIPList) > 0 { // len(nil) = 0
+		eLASTICIP = CloudServiceSettingsModel(ELASTICIPList[0].(map[string]interface{}))
+	}
 	var eFS *models.CloudServiceSettings = nil
 	EFSList := d["e_f_s"].([]interface{})
 	if len(EFSList) > 0 { // len(nil) = 0
 		eFS = CloudServiceSettingsModel(EFSList[0].(map[string]interface{}))
+	}
+	var eKS *models.CloudServiceSettings = nil
+	EKSList := d["e_k_s"].([]interface{})
+	if len(EKSList) > 0 { // len(nil) = 0
+		eKS = CloudServiceSettingsModel(EKSList[0].(map[string]interface{}))
 	}
 	var eLASTICACHE *models.CloudServiceSettings = nil
 	ELASTICACHEList := d["e_l_a_s_t_i_c_a_c_h_e"].([]interface{})
@@ -1116,6 +2010,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(EVENTBRIDGEList) > 0 { // len(nil) = 0
 		eVENTBRIDGE = CloudServiceSettingsModel(EVENTBRIDGEList[0].(map[string]interface{}))
 	}
+	var eVENTGRID *models.CloudServiceSettings = nil
+	EVENTGRIDList := d["e_v_e_n_t_g_r_i_d"].([]interface{})
+	if len(EVENTGRIDList) > 0 { // len(nil) = 0
+		eVENTGRID = CloudServiceSettingsModel(EVENTGRIDList[0].(map[string]interface{}))
+	}
 	var eVENTHUB *models.CloudServiceSettings = nil
 	EVENTHUBList := d["e_v_e_n_t_h_u_b"].([]interface{})
 	if len(EVENTHUBList) > 0 { // len(nil) = 0
@@ -1151,15 +2050,65 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(FSXList) > 0 { // len(nil) = 0
 		fSX = CloudServiceSettingsModel(FSXList[0].(map[string]interface{}))
 	}
+	var fUNCTION *models.CloudServiceSettings = nil
+	FUNCTIONList := d["f_u_n_c_t_i_o_n"].([]interface{})
+	if len(FUNCTIONList) > 0 { // len(nil) = 0
+		fUNCTION = CloudServiceSettingsModel(FUNCTIONList[0].(map[string]interface{}))
+	}
+	var gATEWAYELB *models.CloudServiceSettings = nil
+	GATEWAYELBList := d["g_a_t_e_w_a_y_e_l_b"].([]interface{})
+	if len(GATEWAYELBList) > 0 { // len(nil) = 0
+		gATEWAYELB = CloudServiceSettingsModel(GATEWAYELBList[0].(map[string]interface{}))
+	}
+	var gLOBALNETWORKS *models.CloudServiceSettings = nil
+	GLOBALNETWORKSList := d["g_l_o_b_a_l_n_e_t_w_o_r_k_s"].([]interface{})
+	if len(GLOBALNETWORKSList) > 0 { // len(nil) = 0
+		gLOBALNETWORKS = CloudServiceSettingsModel(GLOBALNETWORKSList[0].(map[string]interface{}))
+	}
 	var gLUE *models.CloudServiceSettings = nil
 	GLUEList := d["g_l_u_e"].([]interface{})
 	if len(GLUEList) > 0 { // len(nil) = 0
 		gLUE = CloudServiceSettingsModel(GLUEList[0].(map[string]interface{}))
 	}
+	var hEALTHCHECK *models.CloudServiceSettings = nil
+	HEALTHCHECKList := d["h_e_a_l_t_h_c_h_e_c_k"].([]interface{})
+	if len(HEALTHCHECKList) > 0 { // len(nil) = 0
+		hEALTHCHECK = CloudServiceSettingsModel(HEALTHCHECKList[0].(map[string]interface{}))
+	}
+	var hDINSIGHT *models.CloudServiceSettings = nil
+	HDINSIGHTList := d["h_d_i_n_s_i_g_h_t"].([]interface{})
+	if len(HDINSIGHTList) > 0 { // len(nil) = 0
+		hDINSIGHT = CloudServiceSettingsModel(HDINSIGHTList[0].(map[string]interface{}))
+	}
+	var hOSTEDZONE *models.CloudServiceSettings = nil
+	HOSTEDZONEList := d["h_o_s_t_e_d_z_o_n_e"].([]interface{})
+	if len(HOSTEDZONEList) > 0 { // len(nil) = 0
+		hOSTEDZONE = CloudServiceSettingsModel(HOSTEDZONEList[0].(map[string]interface{}))
+	}
+	var iAMROLE *models.CloudServiceSettings = nil
+	IAMROLEList := d["i_a_m_r_o_l_e"].([]interface{})
+	if len(IAMROLEList) > 0 { // len(nil) = 0
+		iAMROLE = CloudServiceSettingsModel(IAMROLEList[0].(map[string]interface{}))
+	}
+	var iNTERNETGATEWAY *models.CloudServiceSettings = nil
+	INTERNETGATEWAYList := d["i_n_t_e_r_n_e_t_g_a_t_e_w_a_y"].([]interface{})
+	if len(INTERNETGATEWAYList) > 0 { // len(nil) = 0
+		iNTERNETGATEWAY = CloudServiceSettingsModel(INTERNETGATEWAYList[0].(map[string]interface{}))
+	}
+	var iOTHUB *models.CloudServiceSettings = nil
+	IOTHUBList := d["i_o_t_h_u_b"].([]interface{})
+	if len(IOTHUBList) > 0 { // len(nil) = 0
+		iOTHUB = CloudServiceSettingsModel(IOTHUBList[0].(map[string]interface{}))
+	}
 	var kEYVAULT *models.CloudServiceSettings = nil
 	KEYVAULTList := d["k_e_y_v_a_u_l_t"].([]interface{})
 	if len(KEYVAULTList) > 0 { // len(nil) = 0
 		kEYVAULT = CloudServiceSettingsModel(KEYVAULTList[0].(map[string]interface{}))
+	}
+	var kMS *models.CloudServiceSettings = nil
+	KMSList := d["k_m_s"].([]interface{})
+	if len(KMSList) > 0 { // len(nil) = 0
+		kMS = CloudServiceSettingsModel(KMSList[0].(map[string]interface{}))
 	}
 	var kINESIS *models.CloudServiceSettings = nil
 	KINESISList := d["k_i_n_e_s_i_s"].([]interface{})
@@ -1175,6 +2124,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	LAMBDAList := d["l_a_m_b_d_a"].([]interface{})
 	if len(LAMBDAList) > 0 { // len(nil) = 0
 		lAMBDA = CloudServiceSettingsModel(LAMBDAList[0].(map[string]interface{}))
+	}
+	var lIGHTSAIL *models.CloudServiceSettings = nil
+	LIGHTSAILList := d["l_i_g_h_t_s_a_i_l"].([]interface{})
+	if len(LIGHTSAILList) > 0 { // len(nil) = 0
+		lIGHTSAIL = CloudServiceSettingsModel(LIGHTSAILList[0].(map[string]interface{}))
 	}
 	var lOADBALANCERS *models.CloudServiceSettings = nil
 	LOADBALANCERSList := d["l_o_a_d_b_a_l_a_n_c_e_r_s"].([]interface{})
@@ -1221,10 +2175,20 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(MEDIATAILORList) > 0 { // len(nil) = 0
 		mEDIATAILOR = CloudServiceSettingsModel(MEDIATAILORList[0].(map[string]interface{}))
 	}
+	var mLWORKSPACES *models.CloudServiceSettings = nil
+	MLWORKSPACESList := d["m_l_w_o_r_k_s_p_a_c_e_s"].([]interface{})
+	if len(MLWORKSPACESList) > 0 { // len(nil) = 0
+		mLWORKSPACES = CloudServiceSettingsModel(MLWORKSPACESList[0].(map[string]interface{}))
+	}
 	var mQ *models.CloudServiceSettings = nil
 	MQList := d["m_q"].([]interface{})
 	if len(MQList) > 0 { // len(nil) = 0
 		mQ = CloudServiceSettingsModel(MQList[0].(map[string]interface{}))
+	}
+	var mARIADB *models.CloudServiceSettings = nil
+	MARIADBList := d["m_a_r_i_a_d_b"].([]interface{})
+	if len(MARIADBList) > 0 { // len(nil) = 0
+		mARIADB = CloudServiceSettingsModel(MARIADBList[0].(map[string]interface{}))
 	}
 	var mSKBROKER *models.CloudServiceSettings = nil
 	MSKBROKERList := d["m_s_k_b_r_o_k_e_r"].([]interface{})
@@ -1241,6 +2205,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(MYSQLList) > 0 { // len(nil) = 0
 		mYSQL = CloudServiceSettingsModel(MYSQLList[0].(map[string]interface{}))
 	}
+	var mYSQLFLEXIBLE *models.CloudServiceSettings = nil
+	MYSQLFLEXIBLEList := d["m_y_sql_f_l_e_x_i_b_l_e"].([]interface{})
+	if len(MYSQLFLEXIBLEList) > 0 { // len(nil) = 0
+		mYSQLFLEXIBLE = CloudServiceSettingsModel(MYSQLFLEXIBLEList[0].(map[string]interface{}))
+	}
 	var nATGATEWAY *models.CloudServiceSettings = nil
 	NATGATEWAYList := d["n_a_t_g_a_t_e_w_a_y"].([]interface{})
 	if len(NATGATEWAYList) > 0 { // len(nil) = 0
@@ -1251,10 +2220,40 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(NETWORKELBList) > 0 { // len(nil) = 0
 		nETWORKELB = CloudServiceSettingsModel(NETWORKELBList[0].(map[string]interface{}))
 	}
+	var nETWORKFIREWALL *models.CloudServiceSettings = nil
+	NETWORKFIREWALLList := d["n_e_t_w_o_r_k_f_i_r_e_w_a_l_l"].([]interface{})
+	if len(NETWORKFIREWALLList) > 0 { // len(nil) = 0
+		nETWORKFIREWALL = CloudServiceSettingsModel(NETWORKFIREWALLList[0].(map[string]interface{}))
+	}
 	var nETWORKINTERFACE *models.CloudServiceSettings = nil
+	var nATGATEWAYS *models.CloudServiceSettings = nil
+	NATGATEWAYSList := d["n_a_t_g_a_t_e_w_a_y_s"].([]interface{})
+	if len(NATGATEWAYSList) > 0 { // len(nil) = 0
+		nATGATEWAYS = CloudServiceSettingsModel(NATGATEWAYSList[0].(map[string]interface{}))
+	}
+	var nETAPPPOOLS *models.CloudServiceSettings = nil
+	NETAPPPOOLSList := d["n_e_t_a_p_p_p_o_o_l_s"].([]interface{})
+	if len(NETAPPPOOLSList) > 0 { // len(nil) = 0
+		nETAPPPOOLS = CloudServiceSettingsModel(NETAPPPOOLSList[0].(map[string]interface{}))
+	}
 	NETWORKINTERFACEList := d["n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e"].([]interface{})
 	if len(NETWORKINTERFACEList) > 0 { // len(nil) = 0
 		nETWORKINTERFACE = CloudServiceSettingsModel(NETWORKINTERFACEList[0].(map[string]interface{}))
+	}
+	var nLBTARGETGROUP *models.CloudServiceSettings = nil
+	NLBTARGETGROUPList := d["n_l_b_t_a_r_g_e_t_g_r_o_u_p"].([]interface{})
+	if len(NLBTARGETGROUPList) > 0 { // len(nil) = 0
+		nLBTARGETGROUP = CloudServiceSettingsModel(NLBTARGETGROUPList[0].(map[string]interface{}))
+	}
+	var nOTIFICATIONHUBS *models.CloudServiceSettings = nil
+	NOTIFICATIONHUBSList := d["n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s"].([]interface{})
+	if len(NOTIFICATIONHUBSList) > 0 { // len(nil) = 0
+		nOTIFICATIONHUBS = CloudServiceSettingsModel(NOTIFICATIONHUBSList[0].(map[string]interface{}))
+	}
+	var oPENAISERVICES *models.CloudServiceSettings = nil
+	OPENAISERVICESList := d["o_p_e_n_a_i_s_e_r_v_i_c_e_s"].([]interface{})
+	if len(OPENAISERVICESList) > 0 { // len(nil) = 0
+		oPENAISERVICES = CloudServiceSettingsModel(OPENAISERVICESList[0].(map[string]interface{}))
 	}
 	var oPSWORKS *models.CloudServiceSettings = nil
 	OPSWORKSList := d["o_p_s_w_o_r_k_s"].([]interface{})
@@ -1266,15 +2265,60 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(POSTGRESQLList) > 0 { // len(nil) = 0
 		pOSTGRESQL = CloudServiceSettingsModel(POSTGRESQLList[0].(map[string]interface{}))
 	}
+	var pOSTGRESQLCITUS *models.CloudServiceSettings = nil
+	POSTGRESQLCITUSList := d["p_o_s_t_g_r_e_sql_c_i_t_u_s"].([]interface{})
+	if len(POSTGRESQLCITUSList) > 0 { // len(nil) = 0
+		pOSTGRESQLCITUS = CloudServiceSettingsModel(POSTGRESQLCITUSList[0].(map[string]interface{}))
+	}
+	var pOSTGRESQLFLEXIBLE *models.CloudServiceSettings = nil
+	POSTGRESQLFLEXIBLEList := d["p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e"].([]interface{})
+	if len(POSTGRESQLFLEXIBLEList) > 0 { // len(nil) = 0
+		pOSTGRESQLFLEXIBLE = CloudServiceSettingsModel(POSTGRESQLFLEXIBLEList[0].(map[string]interface{}))
+	}
+	var pOWERBIEMBEDDED *models.CloudServiceSettings = nil
+	POWERBIEMBEDDEDList := d["p_o_w_e_r_b_i_e_m_b_e_d_d_e_d"].([]interface{})
+	if len(POWERBIEMBEDDEDList) > 0 { // len(nil) = 0
+		pOWERBIEMBEDDED = CloudServiceSettingsModel(POWERBIEMBEDDEDList[0].(map[string]interface{}))
+	}
 	var pUBLICIP *models.CloudServiceSettings = nil
 	PUBLICIPList := d["p_u_b_l_i_c_ip"].([]interface{})
 	if len(PUBLICIPList) > 0 { // len(nil) = 0
 		pUBLICIP = CloudServiceSettingsModel(PUBLICIPList[0].(map[string]interface{}))
 	}
+	var pRIVATELINKENDPOINTS *models.CloudServiceSettings = nil
+	PRIVATELINKENDPOINTSList := d["p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s"].([]interface{})
+	if len(PRIVATELINKENDPOINTSList) > 0 { // len(nil) = 0
+		pRIVATELINKENDPOINTS = CloudServiceSettingsModel(PRIVATELINKENDPOINTSList[0].(map[string]interface{}))
+	}
+	var pRIVATELINKSERVICES *models.CloudServiceSettings = nil
+	PRIVATELINKSERVICESList := d["p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s"].([]interface{})
+	if len(PRIVATELINKSERVICESList) > 0 { // len(nil) = 0
+		pRIVATELINKSERVICES = CloudServiceSettingsModel(PRIVATELINKSERVICESList[0].(map[string]interface{}))
+	}
+	var qBUSINESS *models.CloudServiceSettings = nil
+	QBUSINESSList := d["q_b_u_s_i_n_e_s_s"].([]interface{})
+	if len(QBUSINESSList) > 0 { // len(nil) = 0
+		qBUSINESS = CloudServiceSettingsModel(QBUSINESSList[0].(map[string]interface{}))
+	}
+	var qUOTA *models.CloudServiceSettings = nil
+	QUOTAList := d["q_u_o_t_a"].([]interface{})
+	if len(QUOTAList) > 0 { // len(nil) = 0
+		qUOTA = CloudServiceSettingsModel(QUOTAList[0].(map[string]interface{}))
+	}
 	var qUEUESTORAGE *models.CloudServiceSettings = nil
 	QUEUESTORAGEList := d["q_u_e_u_e_s_t_o_r_a_g_e"].([]interface{})
 	if len(QUEUESTORAGEList) > 0 { // len(nil) = 0
 		qUEUESTORAGE = CloudServiceSettingsModel(QUEUESTORAGEList[0].(map[string]interface{}))
+	}
+	var qUICKSIGHTDASHBOARDS *models.CloudServiceSettings = nil
+	QUICKSIGHTDASHBOARDSList := d["q_u_i_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s"].([]interface{})
+	if len(QUICKSIGHTDASHBOARDSList) > 0 { // len(nil) = 0
+		qUICKSIGHTDASHBOARDS = CloudServiceSettingsModel(QUICKSIGHTDASHBOARDSList[0].(map[string]interface{}))
+	}
+	var qUICKSIGHTDATASETS *models.CloudServiceSettings = nil
+	QUICKSIGHTDATASETSList := d["q_u_i_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s"].([]interface{})
+	if len(QUICKSIGHTDATASETSList) > 0 { // len(nil) = 0
+		qUICKSIGHTDATASETS = CloudServiceSettingsModel(QUICKSIGHTDATASETSList[0].(map[string]interface{}))
 	}
 	var rDS *models.CloudServiceSettings = nil
 	RDSList := d["r_d_s"].([]interface{})
@@ -1286,6 +2330,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(RECOVERYPROTECTEDITEMList) > 0 { // len(nil) = 0
 		rECOVERYPROTECTEDITEM = CloudServiceSettingsModel(RECOVERYPROTECTEDITEMList[0].(map[string]interface{}))
 	}
+	var rECOVERYPROTECTEDITEMS *models.CloudServiceSettings = nil
+	RECOVERYPROTECTEDITEMSList := d["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s"].([]interface{})
+	if len(RECOVERYPROTECTEDITEMSList) > 0 { // len(nil) = 0
+		rECOVERYPROTECTEDITEMS = CloudServiceSettingsModel(RECOVERYPROTECTEDITEMSList[0].(map[string]interface{}))
+	}
 	var rECOVERYSERVICES *models.CloudServiceSettings = nil
 	RECOVERYSERVICESList := d["r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s"].([]interface{})
 	if len(RECOVERYSERVICESList) > 0 { // len(nil) = 0
@@ -1296,15 +2345,35 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(REDISCACHEList) > 0 { // len(nil) = 0
 		rEDISCACHE = CloudServiceSettingsModel(REDISCACHEList[0].(map[string]interface{}))
 	}
+	var rEDISCACHEENTERPRISE *models.CloudServiceSettings = nil
+	REDISCACHEENTERPRISEList := d["r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e"].([]interface{})
+	if len(REDISCACHEENTERPRISEList) > 0 { // len(nil) = 0
+		rEDISCACHEENTERPRISE = CloudServiceSettingsModel(REDISCACHEENTERPRISEList[0].(map[string]interface{}))
+	}
 	var rEDSHIFT *models.CloudServiceSettings = nil
 	REDSHIFTList := d["r_e_d_s_h_i_f_t"].([]interface{})
 	if len(REDSHIFTList) > 0 { // len(nil) = 0
 		rEDSHIFT = CloudServiceSettingsModel(REDSHIFTList[0].(map[string]interface{}))
 	}
+	var rEDSHIFTSERVERLESS *models.CloudServiceSettings = nil
+	REDSHIFTSERVERLESSList := d["r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s"].([]interface{})
+	if len(REDSHIFTSERVERLESSList) > 0 { // len(nil) = 0
+		rEDSHIFTSERVERLESS = CloudServiceSettingsModel(REDSHIFTSERVERLESSList[0].(map[string]interface{}))
+	}
+	var rELAYNAMESPACES *models.CloudServiceSettings = nil
+	RELAYNAMESPACESList := d["r_e_l_a_y_n_a_m_e_s_p_a_c_e_s"].([]interface{})
+	if len(RELAYNAMESPACESList) > 0 { // len(nil) = 0
+		rELAYNAMESPACES = CloudServiceSettingsModel(RELAYNAMESPACESList[0].(map[string]interface{}))
+	}
 	var rOUTE53 *models.CloudServiceSettings = nil
 	ROUTE53List := d["r_o_u_t_e53"].([]interface{})
 	if len(ROUTE53List) > 0 { // len(nil) = 0
 		rOUTE53 = CloudServiceSettingsModel(ROUTE53List[0].(map[string]interface{}))
+	}
+	var rOUTE53HOSTEDZONE *models.CloudServiceSettings = nil
+	ROUTE53HOSTEDZONEList := d["r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e"].([]interface{})
+	if len(ROUTE53HOSTEDZONEList) > 0 { // len(nil) = 0
+		rOUTE53HOSTEDZONE = CloudServiceSettingsModel(ROUTE53HOSTEDZONEList[0].(map[string]interface{}))
 	}
 	var rOUTE53RESOLVER *models.CloudServiceSettings = nil
 	ROUTE53RESOLVERList := d["r_o_u_t_e53_r_e_s_o_l_v_e_r"].([]interface{})
@@ -1326,10 +2395,25 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(SERVICEBUSList) > 0 { // len(nil) = 0
 		sERVICEBUS = CloudServiceSettingsModel(SERVICEBUSList[0].(map[string]interface{}))
 	}
+	var sERVICEFABRICMESH *models.CloudServiceSettings = nil
+	SERVICEFABRICMESHList := d["s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h"].([]interface{})
+	if len(SERVICEFABRICMESHList) > 0 { // len(nil) = 0
+		sERVICEFABRICMESH = CloudServiceSettingsModel(SERVICEFABRICMESHList[0].(map[string]interface{}))
+	}
 	var sES *models.CloudServiceSettings = nil
 	SESList := d["s_e_s"].([]interface{})
 	if len(SESList) > 0 { // len(nil) = 0
 		sES = CloudServiceSettingsModel(SESList[0].(map[string]interface{}))
+	}
+	var sIGNALR *models.CloudServiceSettings = nil
+	SIGNALRList := d["s_i_g_n_a_l_r"].([]interface{})
+	if len(SIGNALRList) > 0 { // len(nil) = 0
+		sIGNALR = CloudServiceSettingsModel(SIGNALRList[0].(map[string]interface{}))
+	}
+	var sITE2SITEVPN *models.CloudServiceSettings = nil
+	SITE2SITEVPNList := d["s_i_t_e2_s_i_t_e_v_p_n"].([]interface{})
+	if len(SITE2SITEVPNList) > 0 { // len(nil) = 0
+		sITE2SITEVPN = CloudServiceSettingsModel(SITE2SITEVPNList[0].(map[string]interface{}))
 	}
 	var sNS *models.CloudServiceSettings = nil
 	SNSList := d["s_n_s"].([]interface{})
@@ -1366,6 +2450,16 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(STORAGEACCOUNTList) > 0 { // len(nil) = 0
 		sTORAGEACCOUNT = CloudServiceSettingsModel(STORAGEACCOUNTList[0].(map[string]interface{}))
 	}
+	var sTORAGEGATEWAY *models.CloudServiceSettings = nil
+	STORAGEGATEWAYList := d["s_t_o_r_a_g_e_g_a_t_e_w_a_y"].([]interface{})
+	if len(STORAGEGATEWAYList) > 0 { // len(nil) = 0
+		sTORAGEGATEWAY = CloudServiceSettingsModel(STORAGEGATEWAYList[0].(map[string]interface{}))
+	}
+	var sTREAMANALYTICS *models.CloudServiceSettings = nil
+	STREAMANALYTICSList := d["s_t_r_e_a_m_a_n_a_l_y_t_i_c_s"].([]interface{})
+	if len(STREAMANALYTICSList) > 0 { // len(nil) = 0
+		sTREAMANALYTICS = CloudServiceSettingsModel(STREAMANALYTICSList[0].(map[string]interface{}))
+	}
 	var sWFACTIVITY *models.CloudServiceSettings = nil
 	SWFACTIVITYList := d["s_w_f_a_c_t_i_v_i_t_y"].([]interface{})
 	if len(SWFACTIVITYList) > 0 { // len(nil) = 0
@@ -1391,15 +2485,30 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(TRAFFICMANAGERList) > 0 { // len(nil) = 0
 		tRAFFICMANAGER = CloudServiceSettingsModel(TRAFFICMANAGERList[0].(map[string]interface{}))
 	}
+	var tRANSFER *models.CloudServiceSettings = nil
+	TRANSFERList := d["t_r_a_n_s_f_e_r"].([]interface{})
+	if len(TRANSFERList) > 0 { // len(nil) = 0
+		tRANSFER = CloudServiceSettingsModel(TRANSFERList[0].(map[string]interface{}))
+	}
 	var tRANSITGATEWAY *models.CloudServiceSettings = nil
 	TRANSITGATEWAYList := d["t_r_a_n_s_i_t_g_a_t_e_w_a_y"].([]interface{})
 	if len(TRANSITGATEWAYList) > 0 { // len(nil) = 0
 		tRANSITGATEWAY = CloudServiceSettingsModel(TRANSITGATEWAYList[0].(map[string]interface{}))
 	}
+	var tRANSITGATEWAYATTACHMENT *models.CloudServiceSettings = nil
+	TRANSITGATEWAYATTACHMENTList := d["t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t"].([]interface{})
+	if len(TRANSITGATEWAYATTACHMENTList) > 0 { // len(nil) = 0
+		tRANSITGATEWAYATTACHMENT = CloudServiceSettingsModel(TRANSITGATEWAYATTACHMENTList[0].(map[string]interface{}))
+	}
 	var vIRTUALDESKTOP *models.CloudServiceSettings = nil
 	VIRTUALDESKTOPList := d["v_i_r_t_u_a_l_d_e_s_k_t_o_p"].([]interface{})
 	if len(VIRTUALDESKTOPList) > 0 { // len(nil) = 0
 		vIRTUALDESKTOP = CloudServiceSettingsModel(VIRTUALDESKTOPList[0].(map[string]interface{}))
+	}
+	var vIRTUALHUBS *models.CloudServiceSettings = nil
+	VIRTUALHUBSList := d["v_i_r_t_u_a_l_h_u_b_s"].([]interface{})
+	if len(VIRTUALHUBSList) > 0 { // len(nil) = 0
+		vIRTUALHUBS = CloudServiceSettingsModel(VIRTUALHUBSList[0].(map[string]interface{}))
 	}
 	var vIRTUALMACHINE *models.CloudServiceSettings = nil
 	VIRTUALMACHINEList := d["v_i_r_t_u_a_l_m_a_c_h_i_n_e"].([]interface{})
@@ -1421,10 +2530,35 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(VIRTUALNETWORKGATEWAYList) > 0 { // len(nil) = 0
 		vIRTUALNETWORKGATEWAY = CloudServiceSettingsModel(VIRTUALNETWORKGATEWAYList[0].(map[string]interface{}))
 	}
+	var vIRTUALNETWORKS *models.CloudServiceSettings = nil
+	VIRTUALNETWORKSList := d["v_i_r_t_u_a_l_n_e_t_w_o_r_k_s"].([]interface{})
+	if len(VIRTUALNETWORKSList) > 0 { // len(nil) = 0
+		vIRTUALNETWORKS = CloudServiceSettingsModel(VIRTUALNETWORKSList[0].(map[string]interface{}))
+	}
+	var vPC *models.CloudServiceSettings = nil
+	VPCList := d["v_p_c"].([]interface{})
+	if len(VPCList) > 0 { // len(nil) = 0
+		vPC = CloudServiceSettingsModel(VPCList[0].(map[string]interface{}))
+	}
+	var vPCENDPOINT *models.CloudServiceSettings = nil
+	VPCENDPOINTList := d["v_p_c_e_n_d_p_o_i_n_t"].([]interface{})
+	if len(VPCENDPOINTList) > 0 { // len(nil) = 0
+		vPCENDPOINT = CloudServiceSettingsModel(VPCENDPOINTList[0].(map[string]interface{}))
+	}
+	var vPCPEERING *models.CloudServiceSettings = nil
+	VPCPEERINGList := d["v_p_c_p_e_e_r_i_n_g"].([]interface{})
+	if len(VPCPEERINGList) > 0 { // len(nil) = 0
+		vPCPEERING = CloudServiceSettingsModel(VPCPEERINGList[0].(map[string]interface{}))
+	}
 	var vPN *models.CloudServiceSettings = nil
 	VPNList := d["v_p_n"].([]interface{})
 	if len(VPNList) > 0 { // len(nil) = 0
 		vPN = CloudServiceSettingsModel(VPNList[0].(map[string]interface{}))
+	}
+	var vPNGATEWAYS *models.CloudServiceSettings = nil
+	VPNGATEWAYSList := d["v_p_n_g_a_t_e_w_a_y_s"].([]interface{})
+	if len(VPNGATEWAYSList) > 0 { // len(nil) = 0
+		vPNGATEWAYS = CloudServiceSettingsModel(VPNGATEWAYSList[0].(map[string]interface{}))
 	}
 	var wORKSPACE *models.CloudServiceSettings = nil
 	WORKSPACEList := d["w_o_r_k_s_p_a_c_e"].([]interface{})
@@ -1438,142 +2572,256 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	}
 
 	return &models.CloudServices{
-		APIGATEWAY:               aPIGATEWAY,
-		APIMANAGEMENT:            aPIMANAGEMENT,
-		APPLICATIONELB:           aPPLICATIONELB,
-		APPLICATIONGATEWAY:       aPPLICATIONGATEWAY,
-		APPLICATIONINSIGHTS:      aPPLICATIONINSIGHTS,
-		APPSERVICE:               aPPSERVICE,
-		APPSERVICEPLAN:           aPPSERVICEPLAN,
-		APPSTREAM:                aPPSTREAM,
-		ATHENA:                   aTHENA,
-		AUTOMATIONACCOUNT:        aUTOMATIONACCOUNT,
-		AUTOSCALING:              aUTOSCALING,
-		BACKUPPROTECTEDITEMS:     bACKUPPROTECTEDITEMS,
-		BLOBSTORAGE:              bLOBSTORAGE,
-		CLOUDFRONT:               cLOUDFRONT,
-		CLOUDSEARCH:              cLOUDSEARCH,
-		CODEBUILD:                cODEBUILD,
-		COGNITIVESEARCH:          cOGNITIVESEARCH,
-		COGNITIVESERVICES:        cOGNITIVESERVICES,
-		COGNITO:                  cOGNITO,
-		COSMOSDB:                 cOSMOSDB,
-		DATAFACTORY:              dATAFACTORY,
-		DIRECTCONNECT:            dIRECTCONNECT,
-		DMSREPLICATION:           dMSREPLICATION,
-		DMSREPLICATIONTASKS:      dMSREPLICATIONTASKS,
-		DOCDB:                    dOCDB,
-		DYNAMODB:                 dYNAMODB,
-		EBS:                      eBS,
-		EC2:                      eC2,
-		ECS:                      eCS,
-		EFS:                      eFS,
-		ELASTICACHE:              eLASTICACHE,
-		ELASTICBEANSTALK:         eLASTICBEANSTALK,
-		ELASTICSEARCH:            eLASTICSEARCH,
-		ELASTICTRANSCODER:        eLASTICTRANSCODER,
-		ELB:                      eLB,
-		EMR:                      eMR,
-		EVENTBRIDGE:              eVENTBRIDGE,
-		EVENTHUB:                 eVENTHUB,
-		EXPRESSROUTECIRCUIT:      eXPRESSROUTECIRCUIT,
-		FILESTORAGE:              fILESTORAGE,
-		FIREHOSE:                 fIREHOSE,
-		FIREWALL:                 fIREWALL,
-		FRONTDOORS:               fRONTDOORS,
-		FSX:                      fSX,
-		GLUE:                     gLUE,
-		KEYVAULT:                 kEYVAULT,
-		KINESIS:                  kINESIS,
-		KINESISVIDEO:             kINESISVIDEO,
-		LAMBDA:                   lAMBDA,
-		LOADBALANCERS:            lOADBALANCERS,
-		LOGANALYTICSWORKSPACES:   lOGANALYTICSWORKSPACES,
-		LOGICAPPS:                lOGICAPPS,
-		MEDIACONNECT:             mEDIACONNECT,
-		MEDIACONVERT:             mEDIACONVERT,
-		MEDIAPACKAGELIVE:         mEDIAPACKAGELIVE,
-		MEDIAPACKAGEVOD:          mEDIAPACKAGEVOD,
-		MEDIASTORE:               mEDIASTORE,
-		MEDIATAILOR:              mEDIATAILOR,
-		MQ:                       mQ,
-		MSKBROKER:                mSKBROKER,
-		MSKCLUSTER:               mSKCLUSTER,
-		MYSQL:                    mYSQL,
-		NATGATEWAY:               nATGATEWAY,
-		NETWORKELB:               nETWORKELB,
-		NETWORKINTERFACE:         nETWORKINTERFACE,
-		OPSWORKS:                 oPSWORKS,
-		POSTGRESQL:               pOSTGRESQL,
-		PUBLICIP:                 pUBLICIP,
-		QUEUESTORAGE:             qUEUESTORAGE,
-		RDS:                      rDS,
-		RECOVERYPROTECTEDITEM:    rECOVERYPROTECTEDITEM,
-		RECOVERYSERVICES:         rECOVERYSERVICES,
-		REDISCACHE:               rEDISCACHE,
-		REDSHIFT:                 rEDSHIFT,
-		ROUTE53:                  rOUTE53,
-		ROUTE53RESOLVER:          rOUTE53RESOLVER,
-		S3:                       s3,
-		SAGEMAKER:                sAGEMAKER,
-		SERVICEBUS:               sERVICEBUS,
-		SES:                      sES,
-		SNS:                      sNS,
-		SQLDATABASE:              sQLDATABASE,
-		SQLELASTICPOOL:           sQLELASTICPOOL,
-		SQLMANAGEDINSTANCE:       sQLMANAGEDINSTANCE,
-		SQS:                      sQS,
-		STEPFUNCTIONS:            sTEPFUNCTIONS,
-		STORAGEACCOUNT:           sTORAGEACCOUNT,
-		SWFACTIVITY:              sWFACTIVITY,
-		SWFWORKFLOW:              sWFWORKFLOW,
-		SYNAPSEWORKSPACES:        sYNAPSEWORKSPACES,
-		TABLESTORAGE:             tABLESTORAGE,
-		TRAFFICMANAGER:           tRAFFICMANAGER,
-		TRANSITGATEWAY:           tRANSITGATEWAY,
-		VIRTUALDESKTOP:           vIRTUALDESKTOP,
-		VIRTUALMACHINE:           vIRTUALMACHINE,
-		VIRTUALMACHINESCALESET:   vIRTUALMACHINESCALESET,
-		VIRTUALMACHINESCALESETVM: vIRTUALMACHINESCALESETVM,
-		VIRTUALNETWORKGATEWAY:    vIRTUALNETWORKGATEWAY,
-		VPN:                      vPN,
-		WORKSPACE:                wORKSPACE,
-		WORKSPACEDIRECTORY:       wORKSPACEDIRECTORY,
+		ACM:                           aCM,
+		AKSMANAGEDCLUSTER:             aKSMANAGEDCLUSTER,
+		ALARMS:                        aLARMS,
+		ANALYSISSERVICE:               aNALYSISSERVICE,
+		APIGATEWAY:                    aPIGATEWAY,
+		APIGATEWAYV2:                  aPIGATEWAYV2,
+		APIMANAGEMENT:                 aPIMANAGEMENT,
+		APPLICATIONELB:                aPPLICATIONELB,
+		APPLICATIONGATEWAY:            aPPLICATIONGATEWAY,
+		APPLICATIONINSIGHTS:           aPPLICATIONINSIGHTS,
+		APPLICATIONMIGRATIONSERVICE:   aPPLICATIONMIGRATIONSERVICE,
+		APPSERVICE:                    aPPSERVICE,
+		APPSERVICEPLAN:                aPPSERVICEPLAN,
+		APPSERVICEENVIRONMENT:         aPPSERVICEENVIRONMENT,
+		APPSTREAM:                     aPPSTREAM,
+		ATHENA:                        aTHENA,
+		AUTOMATIONACCOUNT:             aUTOMATIONACCOUNT,
+		AUTOSCALING:                   aUTOSCALING,
+		BACKUP:                        bACKUP,
+		BACKUPPROTECTEDITEMS:          bACKUPPROTECTEDITEMS,
+		BACKUPPROTECTEDRESOURCE:       bACKUPPROTECTEDRESOURCE,
+		BACKUPVAULT:                   bACKUPVAULT,
+		BATCH:                         bATCH,
+		BATCHACCOUNT:                  bATCHACCOUNT,
+		BEDROCK:                       bEDROCK,
+		BLOBSTORAGE:                   bLOBSTORAGE,
+		BOTSERVICES:                   bOTSERVICES,
+		CDNPROFILE:                    cDNPROFILE,
+		CLIENTVPN:                     cLIENTVPN,
+		CLOUDFRONT:                    cLOUDFRONT,
+		CLOUDSEARCH:                   cLOUDSEARCH,
+		CLOUDTRAIL:                    cLOUDTRAIL,
+		CLOUDWATCHEVENTS:              cLOUDWATCHEVENTS,
+		CLOUDWATCHLOGS:                cLOUDWATCHLOGS,
+		CLOUDWATCHSYNTHETICS:          cLOUDWATCHSYNTHETICS,
+		CODEBUILD:                     cODEBUILD,
+		COGNITIVESEARCH:               cOGNITIVESEARCH,
+		COGNITIVESERVICES:             cOGNITIVESERVICES,
+		COGNITO:                       cOGNITO,
+		CONTAINERAPPS:                 cONTAINERAPPS,
+		CONTAINERINSTANCE:             cONTAINERINSTANCE,
+		CONTAINERREGISTRY:             cONTAINERREGISTRY,
+		COSMOSDB:                      cOSMOSDB,
+		DATAFACTORY:                   dATAFACTORY,
+		DATALAKEANALYTICS:             dATALAKEANALYTICS,
+		DATALAKESTORE:                 dATALAKESTORE,
+		DATABRICKS:                    dATABRICKS,
+		DBCLUSTER:                     dBCLUSTER,
+		DETECTIVEGRAPH:                dETECTIVEGRAPH,
+		DIRECTCONNECT:                 dIRECTCONNECT,
+		DIRECTCONNECTVIRTUALINTERFACE: dIRECTCONNECTVIRTUALINTERFACE,
+		DISKS:                         dISKS,
+		DMSREPLICATION:                dMSREPLICATION,
+		DMSREPLICATIONTASKS:           dMSREPLICATIONTASKS,
+		DOCDB:                         dOCDB,
+		DYNAMODB:                      dYNAMODB,
+		EBS:                           eBS,
+		EC2:                           eC2,
+		ECR:                           eCR,
+		ECS:                           eCS,
+		ELASTICIP:                     eLASTICIP,
+		EFS:                           eFS,
+		EKS:                           eKS,
+		ELASTICACHE:                   eLASTICACHE,
+		ELASTICBEANSTALK:              eLASTICBEANSTALK,
+		ELASTICSEARCH:                 eLASTICSEARCH,
+		ELASTICTRANSCODER:             eLASTICTRANSCODER,
+		ELB:                           eLB,
+		EMR:                           eMR,
+		EVENTBRIDGE:                   eVENTBRIDGE,
+		EVENTGRID:                     eVENTGRID,
+		EVENTHUB:                      eVENTHUB,
+		EXPRESSROUTECIRCUIT:           eXPRESSROUTECIRCUIT,
+		FILESTORAGE:                   fILESTORAGE,
+		FIREHOSE:                      fIREHOSE,
+		FIREWALL:                      fIREWALL,
+		FRONTDOORS:                    fRONTDOORS,
+		FSX:                           fSX,
+		FUNCTION:                      fUNCTION,
+		GATEWAYELB:                    gATEWAYELB,
+		GLOBALNETWORKS:                gLOBALNETWORKS,
+		GLUE:                          gLUE,
+		HEALTHCHECK:                   hEALTHCHECK,
+		HDINSIGHT:                     hDINSIGHT,
+		HOSTEDZONE:                    hOSTEDZONE,
+		IAMROLE:                       iAMROLE,
+		INTERNETGATEWAY:               iNTERNETGATEWAY,
+		IOTHUB:                        iOTHUB,
+		KEYVAULT:                      kEYVAULT,
+		KMS:                           kMS,
+		KINESIS:                       kINESIS,
+		KINESISVIDEO:                  kINESISVIDEO,
+		LAMBDA:                        lAMBDA,
+		LIGHTSAIL:                     lIGHTSAIL,
+		LOADBALANCERS:                 lOADBALANCERS,
+		LOGANALYTICSWORKSPACES:        lOGANALYTICSWORKSPACES,
+		LOGICAPPS:                     lOGICAPPS,
+		MEDIACONNECT:                  mEDIACONNECT,
+		MEDIACONVERT:                  mEDIACONVERT,
+		MEDIAPACKAGELIVE:              mEDIAPACKAGELIVE,
+		MEDIAPACKAGEVOD:               mEDIAPACKAGEVOD,
+		MEDIASTORE:                    mEDIASTORE,
+		MEDIATAILOR:                   mEDIATAILOR,
+		MLWORKSPACES:                  mLWORKSPACES,
+		MQ:                            mQ,
+		MARIADB:                       mARIADB,
+		MSKBROKER:                     mSKBROKER,
+		MSKCLUSTER:                    mSKCLUSTER,
+		MYSQL:                         mYSQL,
+		MYSQLFLEXIBLE:                 mYSQLFLEXIBLE,
+		NATGATEWAY:                    nATGATEWAY,
+		NATGATEWAYS:                   nATGATEWAYS,
+		NETAPPPOOLS:                   nETAPPPOOLS,
+		NETWORKELB:                    nETWORKELB,
+		NETWORKFIREWALL:               nETWORKFIREWALL,
+		NETWORKINTERFACE:              nETWORKINTERFACE,
+		NLBTARGETGROUP:                nLBTARGETGROUP,
+		NOTIFICATIONHUBS:              nOTIFICATIONHUBS,
+		OPENAISERVICES:                oPENAISERVICES,
+		OPSWORKS:                      oPSWORKS,
+		POSTGRESQL:                    pOSTGRESQL,
+		POSTGRESQLCITUS:               pOSTGRESQLCITUS,
+		POSTGRESQLFLEXIBLE:            pOSTGRESQLFLEXIBLE,
+		POWERBIEMBEDDED:               pOWERBIEMBEDDED,
+		PUBLICIP:                      pUBLICIP,
+		PRIVATELINKENDPOINTS:          pRIVATELINKENDPOINTS,
+		PRIVATELINKSERVICES:           pRIVATELINKSERVICES,
+		QBUSINESS:                     qBUSINESS,
+		QUOTA:                         qUOTA,
+		QUEUESTORAGE:                  qUEUESTORAGE,
+		QUICKSIGHTDASHBOARDS:          qUICKSIGHTDASHBOARDS,
+		QUICKSIGHTDATASETS:            qUICKSIGHTDATASETS,
+		RDS:                           rDS,
+		RECOVERYPROTECTEDITEM:         rECOVERYPROTECTEDITEM,
+		RECOVERYPROTECTEDITEMS:        rECOVERYPROTECTEDITEMS,
+		RECOVERYSERVICES:              rECOVERYSERVICES,
+		REDISCACHE:                    rEDISCACHE,
+		REDISCACHEENTERPRISE:          rEDISCACHEENTERPRISE,
+		REDSHIFT:                      rEDSHIFT,
+		REDSHIFTSERVERLESS:            rEDSHIFTSERVERLESS,
+		RELAYNAMESPACES:               rELAYNAMESPACES,
+		ROUTE53:                       rOUTE53,
+		ROUTE53HOSTEDZONE:             rOUTE53HOSTEDZONE,
+		ROUTE53RESOLVER:               rOUTE53RESOLVER,
+		S3:                            s3,
+		SAGEMAKER:                     sAGEMAKER,
+		SERVICEBUS:                    sERVICEBUS,
+		SERVICEFABRICMESH:             sERVICEFABRICMESH,
+		SES:                           sES,
+		SIGNALR:                       sIGNALR,
+		SITE2SITEVPN:                  sITE2SITEVPN,
+		SNS:                           sNS,
+		SQLDATABASE:                   sQLDATABASE,
+		SQLELASTICPOOL:                sQLELASTICPOOL,
+		SQLMANAGEDINSTANCE:            sQLMANAGEDINSTANCE,
+		SQS:                           sQS,
+		STEPFUNCTIONS:                 sTEPFUNCTIONS,
+		STORAGEACCOUNT:                sTORAGEACCOUNT,
+		STORAGEGATEWAY:                sTORAGEGATEWAY,
+		STREAMANALYTICS:               sTREAMANALYTICS,
+		SWFACTIVITY:                   sWFACTIVITY,
+		SWFWORKFLOW:                   sWFWORKFLOW,
+		SYNAPSEWORKSPACES:             sYNAPSEWORKSPACES,
+		TABLESTORAGE:                  tABLESTORAGE,
+		TRAFFICMANAGER:                tRAFFICMANAGER,
+		TRANSFER:                      tRANSFER,
+		TRANSITGATEWAY:                tRANSITGATEWAY,
+		TRANSITGATEWAYATTACHMENT:      tRANSITGATEWAYATTACHMENT,
+		VIRTUALDESKTOP:                vIRTUALDESKTOP,
+		VIRTUALHUBS:                   vIRTUALHUBS,
+		VIRTUALMACHINE:                vIRTUALMACHINE,
+		VIRTUALMACHINESCALESET:        vIRTUALMACHINESCALESET,
+		VIRTUALMACHINESCALESETVM:      vIRTUALMACHINESCALESETVM,
+		VIRTUALNETWORKGATEWAY:         vIRTUALNETWORKGATEWAY,
+		VIRTUALNETWORKS:               vIRTUALNETWORKS,
+		VPC:                           vPC,
+		VPCENDPOINT:                   vPCENDPOINT,
+		VPCPEERING:                    vPCPEERING,
+		VPN:                           vPN,
+		VPNGATEWAYS:                   vPNGATEWAYS,
+		WORKSPACE:                     wORKSPACE,
+		WORKSPACEDIRECTORY:            wORKSPACEDIRECTORY,
 	}
 }
 
 func GetCloudServicesPropertyFields() (t []string) {
 	return []string{
+		"a_c_m",
+		"a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r",
+		"a_l_a_r_m_s",
+		"a_n_a_l_y_s_i_s_s_e_r_v_i_c_e",
 		"api_g_a_t_e_w_a_y",
+		"api_g_a_t_e_w_a_y_v2",
 		"api_m_a_n_a_g_e_m_e_n_t",
 		"a_p_p_l_i_c_a_t_i_o_n_e_l_b",
 		"a_p_p_l_i_c_a_t_i_o_n_g_a_t_e_w_a_y",
 		"a_p_p_l_i_c_a_t_i_o_n_i_n_s_i_g_h_t_s",
+		"a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e",
 		"a_p_p_s_e_r_v_i_c_e",
 		"a_p_p_s_e_r_v_i_c_e_p_l_a_n",
+		"a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t",
 		"a_p_p_s_t_r_e_a_m",
 		"a_t_h_e_n_a",
 		"a_u_t_o_m_a_t_i_o_n_a_c_c_o_u_n_t",
 		"a_u_t_o_s_c_a_l_i_n_g",
+		"b_a_c_k_u_p",
 		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s",
+		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e",
+		"b_a_c_k_u_p_v_a_u_l_t",
+		"b_a_t_c_h",
+		"b_a_t_c_h_a_c_c_o_u_n_t",
+		"b_e_d_r_o_c_k",
 		"b_l_o_b_s_t_o_r_a_g_e",
+		"b_o_t_s_e_r_v_i_c_e_s",
+		"c_d_n_p_r_o_f_i_l_e",
+		"c_l_i_e_n_t_v_p_n",
 		"c_l_o_u_d_f_r_o_n_t",
 		"c_l_o_u_d_s_e_a_r_c_h",
+		"c_l_o_u_d_t_r_a_i_l",
+		"c_l_o_u_d_w_a_t_c_h_e_v_e_n_t_s",
+		"c_l_o_u_d_w_a_t_c_h_l_o_g_s",
+		"c_l_o_u_d_w_a_t_c_h_s_y_n_t_h_e_t_i_c_s",
 		"c_o_d_e_b_ui_l_d",
 		"c_o_g_n_i_t_i_v_e_s_e_a_r_c_h",
 		"c_o_g_n_i_t_i_v_e_s_e_r_v_i_c_e_s",
 		"c_o_g_n_i_t_o",
+		"c_o_n_t_a_i_n_e_r_a_p_p_s",
+		"c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e",
+		"c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y",
 		"c_o_s_m_o_s_d_b",
 		"d_a_t_a_f_a_c_t_o_r_y",
+		"d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s",
+		"d_a_t_a_l_a_k_e_s_t_o_r_e",
+		"d_a_t_a_b_r_i_c_k_s",
+		"d_b_c_l_u_s_t_e_r",
+		"d_e_t_e_c_t_i_v_e_g_r_a_p_h",
 		"d_i_r_e_c_t_c_o_n_n_e_c_t",
+		"d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e",
+		"d_i_s_k_s",
 		"d_m_s_r_e_p_l_i_c_a_t_i_o_n",
 		"d_m_s_r_e_p_l_i_c_a_t_i_o_n_t_a_s_k_s",
 		"d_o_c_d_b",
 		"d_y_n_a_m_o_d_b",
 		"e_b_s",
 		"e_c2",
+		"e_c_r",
 		"e_c_s",
+		"e_l_a_s_t_i_c_ip",
 		"e_f_s",
+		"e_k_s",
 		"e_l_a_s_t_i_c_a_c_h_e",
 		"e_l_a_s_t_i_c_b_e_a_n_s_t_a_l_k",
 		"e_l_a_s_t_i_c_s_e_a_r_c_h",
@@ -1581,6 +2829,7 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"e_l_b",
 		"e_m_r",
 		"e_v_e_n_t_b_r_id_g_e",
+		"e_v_e_n_t_g_r_i_d",
 		"e_v_e_n_t_h_u_b",
 		"e_x_p_r_e_s_s_r_o_u_t_e_c_i_r_c_ui_t",
 		"f_i_l_e_s_t_o_r_a_g_e",
@@ -1588,11 +2837,22 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"f_i_r_e_w_a_l_l",
 		"f_r_o_n_t_d_o_o_r_s",
 		"f_s_x",
+		"f_u_n_c_t_i_o_n",
+		"g_a_t_e_w_a_y_e_l_b",
+		"g_l_o_b_a_l_n_e_t_w_o_r_k_s",
 		"g_l_u_e",
+		"h_e_a_l_t_h_c_h_e_c_k",
+		"h_d_i_n_s_i_g_h_t",
+		"h_o_s_t_e_d_z_o_n_e",
+		"i_a_m_r_o_l_e",
+		"i_n_t_e_r_n_e_t_g_a_t_e_w_a_y",
+		"i_o_t_h_u_b",
 		"k_e_y_v_a_u_l_t",
+		"k_m_s",
 		"k_i_n_e_s_i_s",
 		"k_i_n_e_s_i_s_v_id_e_o",
 		"l_a_m_b_d_a",
+		"l_i_g_h_t_s_a_i_l",
 		"l_o_a_d_b_a_l_a_n_c_e_r_s",
 		"l_o_g_a_n_a_l_y_t_i_c_s_w_o_r_k_s_p_a_c_e_s",
 		"l_o_g_i_c_a_p_p_s",
@@ -1602,28 +2862,54 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"m_e_d_i_a_p_a_c_k_a_g_e_v_o_d",
 		"m_e_d_i_a_s_t_o_r_e",
 		"m_e_d_i_a_t_a_i_l_o_r",
+		"m_l_w_o_r_k_s_p_a_c_e_s",
 		"m_q",
+		"m_a_r_i_a_d_b",
 		"m_s_k_b_r_o_k_e_r",
 		"m_s_k_c_l_u_s_t_e_r",
 		"m_y_sql",
+		"m_y_sql_f_l_e_x_i_b_l_e",
 		"n_a_t_g_a_t_e_w_a_y",
+		"n_a_t_g_a_t_e_w_a_y_s",
+		"n_e_t_a_p_p_p_o_o_l_s",
 		"n_e_t_w_o_r_k_e_l_b",
+		"n_e_t_w_o_r_k_f_i_r_e_w_a_l_l",
 		"n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e",
+		"n_l_b_t_a_r_g_e_t_g_r_o_u_p",
+		"n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s",
+		"o_p_e_n_a_i_s_e_r_v_i_c_e_s",
 		"o_p_s_w_o_r_k_s",
 		"p_o_s_t_g_r_e_sql",
+		"p_o_s_t_g_r_e_sql_c_i_t_u_s",
+		"p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e",
+		"p_o_w_e_r_b_i_e_m_b_e_d_d_e_d",
 		"p_u_b_l_i_c_ip",
+		"p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s",
+		"p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s",
+		"q_b_u_s_i_n_e_s_s",
+		"q_u_o_t_a",
 		"q_u_e_u_e_s_t_o_r_a_g_e",
+		"q_u_i_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s",
+		"q_u_i_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s",
 		"r_d_s",
 		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m",
+		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s",
 		"r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s",
 		"r_e_d_i_s_c_a_c_h_e",
+		"r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e",
 		"r_e_d_s_h_i_f_t",
+		"r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s",
+		"r_e_l_a_y_n_a_m_e_s_p_a_c_e_s",
 		"r_o_u_t_e53",
+		"r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e",
 		"r_o_u_t_e53_r_e_s_o_l_v_e_r",
 		"s3",
 		"s_a_g_e_m_a_k_e_r",
 		"s_e_r_v_i_c_e_b_u_s",
+		"s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h",
 		"s_e_s",
+		"s_i_g_n_a_l_r",
+		"s_i_t_e2_s_i_t_e_v_p_n",
 		"s_n_s",
 		"sql_d_a_t_a_b_a_s_e",
 		"sql_e_l_a_s_t_i_c_p_o_o_l",
@@ -1631,18 +2917,28 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"s_q_s",
 		"s_t_e_p_f_u_n_c_t_i_o_n_s",
 		"s_t_o_r_a_g_e_a_c_c_o_u_n_t",
+		"s_t_o_r_a_g_e_g_a_t_e_w_a_y",
+		"s_t_r_e_a_m_a_n_a_l_y_t_i_c_s",
 		"s_w_f_a_c_t_i_v_i_t_y",
 		"s_w_f_w_o_r_k_f_l_o_w",
 		"s_y_n_a_p_s_e_w_o_r_k_s_p_a_c_e_s",
 		"t_a_b_l_e_s_t_o_r_a_g_e",
 		"t_r_a_f_f_i_c_m_a_n_a_g_e_r",
+		"t_r_a_n_s_f_e_r",
 		"t_r_a_n_s_i_t_g_a_t_e_w_a_y",
+		"t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t",
 		"v_i_r_t_u_a_l_d_e_s_k_t_o_p",
+		"v_i_r_t_u_a_l_h_u_b_s",
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e",
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t",
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t_vm",
 		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_g_a_t_e_w_a_y",
+		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_s",
+		"v_p_c",
+		"v_p_c_e_n_d_p_o_i_n_t",
+		"v_p_c_p_e_e_r_i_n_g",
 		"v_p_n",
+		"v_p_n_g_a_t_e_w_a_y_s",
 		"w_o_r_k_s_p_a_c_e",
 		"w_o_r_k_s_p_a_c_e_d_i_r_e_c_t_o_r_y",
 	}

--- a/logicmonitor/schemata/cloud_tag_filter_schema.go
+++ b/logicmonitor/schemata/cloud_tag_filter_schema.go
@@ -1,27 +1,26 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CloudTagFilterSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"operation": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -43,11 +42,11 @@ func CloudTagFilterModel(d map[string]interface{}) *models.CloudTagFilter {
 	name := d["name"].(string)
 	operation := d["operation"].(string)
 	value := d["value"].(string)
-	
-	return &models.CloudTagFilter {
-		Name: &name,
+
+	return &models.CloudTagFilter{
+		Name:      &name,
 		Operation: &operation,
-		Value: &value,
+		Value:     &value,
 	}
 }
 

--- a/logicmonitor/schemata/collector_attribute_schema.go
+++ b/logicmonitor/schemata/collector_attribute_schema.go
@@ -1,17 +1,16 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CollectorAttributeSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -29,8 +28,8 @@ func SetCollectorAttributeSubResourceData(m []*models.CollectorAttribute) (d []*
 func CollectorAttributeModel(d map[string]interface{}) *models.CollectorAttribute {
 	// assume that the incoming map only contains the relevant resource data
 	name := d["name"].(string)
-	
-	return &models.CollectorAttribute {
+
+	return &models.CollectorAttribute{
 		Name: &name,
 	}
 }

--- a/logicmonitor/schemata/collector_base_schema.go
+++ b/logicmonitor/schemata/collector_base_schema.go
@@ -1,43 +1,43 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CollectorBaseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"ack_comment": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"acked": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"acked_by": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"acked_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"acked_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"arch": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"automatic_upgrade_info": {
 			Type: schema.TypeList, //GoType: AutomaticUpgradeInfo
 			Elem: &schema.Resource{
@@ -45,156 +45,156 @@ func CollectorBaseSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"backup_agent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"build": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"can_downgrade": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"can_downgrade_reason": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"clear_sent": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"collector_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"collector_device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"collector_size": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"conf_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"created_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"ea": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"enable_fail_back": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_fail_over_on_collector_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"escalating_chain_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"has_fail_over_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"hostname": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"in_s_d_t": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"is_down": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"last_sent_notification_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"last_sent_notification_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"need_auto_create_collector_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"netscan_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"next_recipient": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"next_upgrade_info": {
 			Type: schema.TypeList, //GoType: NextUpgradeInfo
 			Elem: &schema.Resource{
@@ -202,17 +202,17 @@ func CollectorBaseSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"number_of_hosts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"number_of_instances": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"onetime_downgrade_info": {
 			Type: schema.TypeList, //GoType: OnetimeUpgradeInfo
 			Elem: &schema.Resource{
@@ -220,7 +220,7 @@ func CollectorBaseSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"onetime_upgrade_info": {
 			Type: schema.TypeList, //GoType: OnetimeUpgradeInfo
 			Elem: &schema.Resource{
@@ -228,12 +228,12 @@ func CollectorBaseSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"platform": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"predefined_config": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -241,92 +241,91 @@ func CollectorBaseSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"previous_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"resend_ival": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"sbproxy_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"specified_collector_device_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"suppress_alert_clear": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"up_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"updated_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"user_change_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"user_change_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"user_visible_hosts_num": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"watchdog_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"watchdog_updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"watchdog_updated_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"wrapper_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -430,24 +429,24 @@ func CollectorBaseModel(d map[string]interface{}) *models.CollectorBase {
 	resendIval := int32(d["resend_ival"].(int))
 	specifiedCollectorDeviceGroupID := int32(d["specified_collector_device_group_id"].(int))
 	suppressAlertClear := d["suppress_alert_clear"].(bool)
-	
-	return &models.CollectorBase {
-		AutomaticUpgradeInfo: automaticUpgradeInfo,
-		BackupAgentID: backupAgentID,
-		CollectorGroupID: collectorGroupID,
-		CustomProperties: customProperties,
-		Description: description,
-		EnableFailBack: enableFailBack,
+
+	return &models.CollectorBase{
+		AutomaticUpgradeInfo:            automaticUpgradeInfo,
+		BackupAgentID:                   backupAgentID,
+		CollectorGroupID:                collectorGroupID,
+		CustomProperties:                customProperties,
+		Description:                     description,
+		EnableFailBack:                  enableFailBack,
 		EnableFailOverOnCollectorDevice: enableFailOverOnCollectorDevice,
-		EscalatingChainID: escalatingChainID,
-		ID: id,
-		NeedAutoCreateCollectorDevice: needAutoCreateCollectorDevice,
-		NumberOfInstances: numberOfInstances,
-		OnetimeDowngradeInfo: onetimeDowngradeInfo,
-		OnetimeUpgradeInfo: onetimeUpgradeInfo,
-		ResendIval: resendIval,
+		EscalatingChainID:               escalatingChainID,
+		ID:                              id,
+		NeedAutoCreateCollectorDevice:   needAutoCreateCollectorDevice,
+		NumberOfInstances:               numberOfInstances,
+		OnetimeDowngradeInfo:            onetimeDowngradeInfo,
+		OnetimeUpgradeInfo:              onetimeUpgradeInfo,
+		ResendIval:                      resendIval,
 		SpecifiedCollectorDeviceGroupID: specifiedCollectorDeviceGroupID,
-		SuppressAlertClear: suppressAlertClear,
+		SuppressAlertClear:              suppressAlertClear,
 	}
 }
 

--- a/logicmonitor/schemata/collector_group_pagination_response_schema.go
+++ b/logicmonitor/schemata/collector_group_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CollectorGroupPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*CollectorGroup 
+			Type: schema.TypeList, //GoType: []*CollectorGroup
 			Elem: &schema.Resource{
 				Schema: CollectorGroupSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetCollectorGroupPaginationResponseSubResourceData(m []*models.CollectorGro
 func CollectorGroupPaginationResponseModel(d map[string]interface{}) *models.CollectorGroupPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.CollectorGroup)
-	
-	return &models.CollectorGroupPaginationResponse {
+
+	return &models.CollectorGroupPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/collector_group_schema.go
+++ b/logicmonitor/schemata/collector_group_schema.go
@@ -1,48 +1,48 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CollectorGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"auto_balance": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"auto_balance_instance_count_threshold": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"auto_balance_strategy": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"create_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"highest_priority_collector_status": {
 			Type: schema.TypeList, //GoType: RestHighestPriorityCollectorStatus
 			Elem: &schema.Resource{
@@ -50,69 +50,67 @@ func CollectorGroupSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"num_of_collectors": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and CollectorGroupSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceCollectorGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"auto_balance": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"auto_balance_instance_count_threshold": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"auto_balance_strategy": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"create_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"custom_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"highest_priority_collector_status": {
 			Type: schema.TypeList, //GoType: RestHighestPriorityCollectorStatus
 			Elem: &schema.Resource{
@@ -120,31 +118,31 @@ func DataSourceCollectorGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"num_of_collectors": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -192,15 +190,15 @@ func CollectorGroupModel(d *schema.ResourceData) *models.CollectorGroup {
 	description := d.Get("description").(string)
 	id, _ := strconv.Atoi(d.Get("id").(string))
 	name := d.Get("name").(string)
-	
-	return &models.CollectorGroup {
-		AutoBalance: autoBalance,
+
+	return &models.CollectorGroup{
+		AutoBalance:                       autoBalance,
 		AutoBalanceInstanceCountThreshold: autoBalanceInstanceCountThreshold,
-		AutoBalanceStrategy: autoBalanceStrategy,
-		CustomProperties: customProperties,
-		Description: description,
-		ID: int32(id),
-		Name: &name,
+		AutoBalanceStrategy:               autoBalanceStrategy,
+		CustomProperties:                  customProperties,
+		Description:                       description,
+		ID:                                int32(id),
+		Name:                              &name,
 	}
 }
 func GetCollectorGroupPropertyFields() (t []string) {

--- a/logicmonitor/schemata/collector_pagination_response_schema.go
+++ b/logicmonitor/schemata/collector_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func CollectorPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*Collector 
+			Type: schema.TypeList, //GoType: []*Collector
 			Elem: &schema.Resource{
 				Schema: CollectorSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetCollectorPaginationResponseSubResourceData(m []*models.CollectorPaginati
 func CollectorPaginationResponseModel(d map[string]interface{}) *models.CollectorPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.Collector)
-	
-	return &models.CollectorPaginationResponse {
+
+	return &models.CollectorPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/collector_schema.go
+++ b/logicmonitor/schemata/collector_schema.go
@@ -1,45 +1,45 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CollectorSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"ack_comment": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"acked": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"acked_by": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"acked_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"acked_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"arch": {
-			Type: schema.TypeString,
-			Default: "linux64",
+			Type:     schema.TypeString,
+			Default:  "linux64",
 			Optional: true,
 		},
-		
+
 		"automatic_upgrade_info": {
 			Type: schema.TypeList, //GoType: AutomaticUpgradeInfo
 			Elem: &schema.Resource{
@@ -47,132 +47,132 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"backup_agent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"build": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"can_downgrade": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"can_downgrade_reason": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"clear_sent": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"collector_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"collector_device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"collector_size": {
-			Type: schema.TypeString,
-			Default: "medium",
+			Type:     schema.TypeString,
+			Default:  "medium",
 			Optional: true,
 		},
-		
+
 		"company": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"conf_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"created_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"ea": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_fail_back": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_fail_over_on_collector_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"escalating_chain_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"has_fail_over_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"hostname": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"in_s_d_t": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"installer_url_cmds": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -180,43 +180,43 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"is_down": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"last_sent_notification_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"last_sent_notification_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"monitor_others": {
-			Type: schema.TypeBool,
-			Default: true,
+			Type:     schema.TypeBool,
+			Default:  true,
 			Optional: true,
 		},
-		
+
 		"need_auto_create_collector_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"netscan_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"next_recipient": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"next_upgrade_info": {
 			Type: schema.TypeList, //GoType: NextUpgradeInfo
 			Elem: &schema.Resource{
@@ -224,22 +224,22 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"number_of_hosts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"number_of_instances": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"number_of_websites": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"onetime_downgrade_info": {
 			Type: schema.TypeList, //GoType: OnetimeUpgradeInfo
 			Elem: &schema.Resource{
@@ -247,7 +247,7 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"onetime_upgrade_info": {
 			Type: schema.TypeList, //GoType: OnetimeUpgradeInfo
 			Elem: &schema.Resource{
@@ -255,12 +255,12 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"platform": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"predefined_config": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -268,141 +268,139 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"previous_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"resend_ival": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"sbproxy_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"specified_collector_device_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"suppress_alert_clear": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"up_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"updated_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"user_change_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"user_change_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"user_visible_hosts_num": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"user_visible_websites_num": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"watchdog_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"watchdog_updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"watchdog_updated_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"website_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"wrapper_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and CollectorSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceCollectorSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"ack_comment": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"acked": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"acked_by": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"acked_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"acked_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"arch": {
-			Type: schema.TypeString,
-			Default: "linux64",
+			Type:     schema.TypeString,
+			Default:  "linux64",
 			Optional: true,
 		},
-		
+
 		"automatic_upgrade_info": {
 			Type: schema.TypeList, //GoType: AutomaticUpgradeInfo
 			Elem: &schema.Resource{
@@ -410,133 +408,133 @@ func DataSourceCollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"backup_agent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"build": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"can_downgrade": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"can_downgrade_reason": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"clear_sent": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"collector_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_size": {
-			Type: schema.TypeString,
-			Default: "medium",
+			Type:     schema.TypeString,
+			Default:  "medium",
 			Optional: true,
 		},
-		
+
 		"company": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"conf_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"created_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"custom_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"ea": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_fail_back": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_fail_over_on_collector_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"escalating_chain_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"has_fail_over_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"hostname": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"in_s_d_t": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"installer_url_cmds": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -544,43 +542,43 @@ func DataSourceCollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"is_down": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"last_sent_notification_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"last_sent_notification_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"monitor_others": {
-			Type: schema.TypeBool,
-			Default: true,
+			Type:     schema.TypeBool,
+			Default:  true,
 			Optional: true,
 		},
-		
+
 		"need_auto_create_collector_device": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"netscan_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"next_recipient": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"next_upgrade_info": {
 			Type: schema.TypeList, //GoType: NextUpgradeInfo
 			Elem: &schema.Resource{
@@ -588,22 +586,22 @@ func DataSourceCollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"number_of_hosts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"number_of_instances": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"number_of_websites": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"onetime_downgrade_info": {
 			Type: schema.TypeList, //GoType: OnetimeUpgradeInfo
 			Elem: &schema.Resource{
@@ -611,7 +609,7 @@ func DataSourceCollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"onetime_upgrade_info": {
 			Type: schema.TypeList, //GoType: OnetimeUpgradeInfo
 			Elem: &schema.Resource{
@@ -619,12 +617,12 @@ func DataSourceCollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"platform": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"predefined_config": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -632,105 +630,105 @@ func DataSourceCollectorSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"previous_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"resend_ival": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"sbproxy_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"specified_collector_device_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"suppress_alert_clear": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"up_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"updated_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"user_change_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"user_change_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"user_visible_hosts_num": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"user_visible_websites_num": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"watchdog_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"watchdog_updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"watchdog_updated_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"website_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"wrapper_conf": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -918,30 +916,30 @@ func CollectorModel(d *schema.ResourceData) *models.Collector {
 	resendIval := int32(d.Get("resend_ival").(int))
 	specifiedCollectorDeviceGroupID := int32(d.Get("specified_collector_device_group_id").(int))
 	suppressAlertClear := d.Get("suppress_alert_clear").(bool)
-	
-	return &models.Collector {
-		Arch: &arch,
-		AutomaticUpgradeInfo: automaticUpgradeInfo,
-		BackupAgentID: backupAgentID,
-		Build: build,
-		CollectorGroupID: collectorGroupID,
-		CollectorSize: &collectorSize,
-		Company: company,
-		CustomProperties: customProperties,
-		Description: description,
-		Ea: &ea,
-		EnableFailBack: enableFailBack,
+
+	return &models.Collector{
+		Arch:                            &arch,
+		AutomaticUpgradeInfo:            automaticUpgradeInfo,
+		BackupAgentID:                   backupAgentID,
+		Build:                           build,
+		CollectorGroupID:                collectorGroupID,
+		CollectorSize:                   &collectorSize,
+		Company:                         company,
+		CustomProperties:                customProperties,
+		Description:                     description,
+		Ea:                              &ea,
+		EnableFailBack:                  enableFailBack,
 		EnableFailOverOnCollectorDevice: enableFailOverOnCollectorDevice,
-		EscalatingChainID: escalatingChainID,
-		ID: int32(id),
-		MonitorOthers: &monitorOthers,
-		NeedAutoCreateCollectorDevice: needAutoCreateCollectorDevice,
-		NumberOfInstances: numberOfInstances,
-		OnetimeDowngradeInfo: onetimeDowngradeInfo,
-		OnetimeUpgradeInfo: onetimeUpgradeInfo,
-		ResendIval: resendIval,
+		EscalatingChainID:               escalatingChainID,
+		ID:                              int32(id),
+		MonitorOthers:                   &monitorOthers,
+		NeedAutoCreateCollectorDevice:   needAutoCreateCollectorDevice,
+		NumberOfInstances:               numberOfInstances,
+		OnetimeDowngradeInfo:            onetimeDowngradeInfo,
+		OnetimeUpgradeInfo:              onetimeUpgradeInfo,
+		ResendIval:                      resendIval,
 		SpecifiedCollectorDeviceGroupID: specifiedCollectorDeviceGroupID,
-		SuppressAlertClear: suppressAlertClear,
+		SuppressAlertClear:              suppressAlertClear,
 	}
 }
 func GetCollectorPropertyFields() (t []string) {

--- a/logicmonitor/schemata/dashboard_data_schema.go
+++ b/logicmonitor/schemata/dashboard_data_schema.go
@@ -1,32 +1,31 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DashboardDataSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"sharable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -46,9 +45,8 @@ func SetDashboardDataSubResourceData(m []*models.DashboardData) (d []*map[string
 
 func DashboardDataModel(d map[string]interface{}) *models.DashboardData {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.DashboardData {
-	}
+
+	return &models.DashboardData{}
 }
 
 func GetDashboardDataPropertyFields() (t []string) {

--- a/logicmonitor/schemata/dashboard_group_pagination_response_schema.go
+++ b/logicmonitor/schemata/dashboard_group_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DashboardGroupPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*DashboardGroup 
+			Type: schema.TypeList, //GoType: []*DashboardGroup
 			Elem: &schema.Resource{
 				Schema: DashboardGroupSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetDashboardGroupPaginationResponseSubResourceData(m []*models.DashboardGro
 func DashboardGroupPaginationResponseModel(d map[string]interface{}) *models.DashboardGroupPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.DashboardGroup)
-	
-	return &models.DashboardGroupPaginationResponse {
+
+	return &models.DashboardGroupPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/dashboard_group_schema.go
+++ b/logicmonitor/schemata/dashboard_group_schema.go
@@ -1,63 +1,63 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DashboardGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"dashboards": {
-			Type: schema.TypeList, //GoType: []*DashboardData 
+			Type: schema.TypeList, //GoType: []*DashboardData
 			Elem: &schema.Resource{
 				Schema: DashboardDataSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Computed: true,
+			Computed:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"num_of_dashboards": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_dashboards": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"parent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"template": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -65,79 +65,77 @@ func DashboardGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"widget_tokens": {
-			Type: schema.TypeList, //GoType: []*WidgetToken 
+			Type: schema.TypeList, //GoType: []*WidgetToken
 			Elem: &schema.Resource{
 				Schema: WidgetTokenSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and DashboardGroupSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceDashboardGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"dashboards": {
-			Type: schema.TypeList, //GoType: []*DashboardData 
+			Type: schema.TypeList, //GoType: []*DashboardData
 			Elem: &schema.Resource{
 				Schema: DashboardDataSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"num_of_dashboards": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_direct_dashboards": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"parent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"template": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -145,24 +143,24 @@ func DataSourceDashboardGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"widget_tokens": {
-			Type: schema.TypeList, //GoType: []*WidgetToken 
+			Type: schema.TypeList, //GoType: []*WidgetToken
 			Elem: &schema.Resource{
 				Schema: WidgetTokenSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -211,13 +209,13 @@ func DashboardGroupModel(d *schema.ResourceData) *models.DashboardGroup {
 	parentID := int32(d.Get("parent_id").(int))
 	template := d.Get("template")
 	widgetTokens := utils.GetPropFromWTMap(d, "widget_tokens")
-	
-	return &models.DashboardGroup {
-		Description: description,
-		ID: int32(id),
-		Name: &name,
-		ParentID: parentID,
-		Template: template,
+
+	return &models.DashboardGroup{
+		Description:  description,
+		ID:           int32(id),
+		Name:         &name,
+		ParentID:     parentID,
+		Template:     template,
 		WidgetTokens: widgetTokens,
 	}
 }

--- a/logicmonitor/schemata/dashboard_pagination_response_schema.go
+++ b/logicmonitor/schemata/dashboard_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DashboardPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*Dashboard 
+			Type: schema.TypeList, //GoType: []*Dashboard
 			Elem: &schema.Resource{
 				Schema: DashboardSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetDashboardPaginationResponseSubResourceData(m []*models.DashboardPaginati
 func DashboardPaginationResponseModel(d map[string]interface{}) *models.DashboardPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.Dashboard)
-	
-	return &models.DashboardPaginationResponse {
+
+	return &models.DashboardPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/dashboard_schema.go
+++ b/logicmonitor/schemata/dashboard_schema.go
@@ -1,59 +1,59 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DashboardSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"full_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"group_full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"owner": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"sharable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"template": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -61,21 +61,21 @@ func DashboardSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"widget_tokens": {
-			Type: schema.TypeList, //GoType: []*WidgetToken 
+			Type: schema.TypeList, //GoType: []*WidgetToken
 			Elem: &schema.Resource{
 				Schema: WidgetTokenSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"widgets_config": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -83,61 +83,59 @@ func DashboardSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and DashboardSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceDashboardSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"full_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"group_full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"owner": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"sharable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"template": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -145,21 +143,21 @@ func DataSourceDashboardSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"widget_tokens": {
-			Type: schema.TypeList, //GoType: []*WidgetToken 
+			Type: schema.TypeList, //GoType: []*WidgetToken
 			Elem: &schema.Resource{
 				Schema: WidgetTokenSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"widgets_config": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -167,10 +165,10 @@ func DataSourceDashboardSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -225,17 +223,17 @@ func DashboardModel(d *schema.ResourceData) *models.Dashboard {
 	template := d.Get("template")
 	widgetTokens := utils.GetPropFromWTMap(d, "widget_tokens")
 	widgetsConfig := d.Get("widgets_config")
-	
-	return &models.Dashboard {
-		Description: description,
-		GroupID: groupID,
-		GroupName: groupName,
-		ID: int32(id),
-		Name: &name,
-		Owner: owner,
-		Sharable: sharable,
-		Template: template,
-		WidgetTokens: widgetTokens,
+
+	return &models.Dashboard{
+		Description:   description,
+		GroupID:       groupID,
+		GroupName:     groupName,
+		ID:            int32(id),
+		Name:          &name,
+		Owner:         owner,
+		Sharable:      sharable,
+		Template:      template,
+		WidgetTokens:  widgetTokens,
 		WidgetsConfig: widgetsConfig,
 	}
 }

--- a/logicmonitor/schemata/data_point_schema.go
+++ b/logicmonitor/schemata/data_point_schema.go
@@ -1,97 +1,96 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DataPointSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"alert_body": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"alert_clear_transition_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"alert_expr": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"alert_expr_note": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"alert_for_no_data": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"alert_subject": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"alert_transition_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"data_type": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"max_digits": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"max_value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"min_value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"post_processor_method": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"post_processor_param": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"raw_data_field_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -141,25 +140,25 @@ func DataPointModel(d map[string]interface{}) *models.DataPoint {
 	postProcessorParam := d["post_processor_param"].(string)
 	rawDataFieldName := d["raw_data_field_name"].(string)
 	typeVar := int32(d["type"].(int))
-	
-	return &models.DataPoint {
-		AlertBody: alertBody,
+
+	return &models.DataPoint{
+		AlertBody:                    alertBody,
 		AlertClearTransitionInterval: alertClearTransitionInterval,
-		AlertExpr: alertExpr,
-		AlertExprNote: alertExprNote,
-		AlertForNoData: alertForNoData,
-		AlertSubject: alertSubject,
-		AlertTransitionInterval: alertTransitionInterval,
-		DataType: dataType,
-		Description: description,
-		MaxDigits: maxDigits,
-		MaxValue: maxValue,
-		MinValue: minValue,
-		Name: &name,
-		PostProcessorMethod: postProcessorMethod,
-		PostProcessorParam: postProcessorParam,
-		RawDataFieldName: rawDataFieldName,
-		Type: typeVar,
+		AlertExpr:                    alertExpr,
+		AlertExprNote:                alertExprNote,
+		AlertForNoData:               alertForNoData,
+		AlertSubject:                 alertSubject,
+		AlertTransitionInterval:      alertTransitionInterval,
+		DataType:                     dataType,
+		Description:                  description,
+		MaxDigits:                    maxDigits,
+		MaxValue:                     maxValue,
+		MinValue:                     minValue,
+		Name:                         &name,
+		PostProcessorMethod:          postProcessorMethod,
+		PostProcessorParam:           postProcessorParam,
+		RawDataFieldName:             rawDataFieldName,
+		Type:                         typeVar,
 	}
 }
 

--- a/logicmonitor/schemata/datasource_pagination_response_schema.go
+++ b/logicmonitor/schemata/datasource_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DatasourcePaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*Datasource  
+			Type: schema.TypeList, //GoType: []*Datasource
 			Elem: &schema.Resource{
 				Schema: DatasourceSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetDatasourcePaginationResponseSubResourceData(m []*models.DatasourcePagina
 func DatasourcePaginationResponseModel(d map[string]interface{}) *models.DatasourcePaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.Datasource)
-	
-	return &models.DatasourcePaginationResponse {
+
+	return &models.DatasourcePaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/datasource_schema.go
+++ b/logicmonitor/schemata/datasource_schema.go
@@ -1,10 +1,10 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DatasourceSchema() map[string]*schema.Schema {
@@ -12,31 +12,31 @@ func DatasourceSchema() map[string]*schema.Schema {
 		"access_group_ids": {
 			Type: schema.TypeList, //GoType: []int32
 			Elem: &schema.Schema{
-                 Type: schema.TypeInt,
-            },
+				Type: schema.TypeInt,
+			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"access_groups": {
-			Type: schema.TypeList, //GoType: []*AccessGroup  
+			Type: schema.TypeList, //GoType: []*AccessGroup
 			Elem: &schema.Resource{
 				Schema: AccessGroupSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"applies_to": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"audit_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"auto_discovery_config": {
 			Type: schema.TypeList, //GoType: AutoDiscoveryConfiguration
 			Elem: &schema.Resource{
@@ -44,60 +44,60 @@ func DatasourceSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"checksum": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"collect_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"collect_method": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"collector_attribute": {
-			Type: schema.TypeList, //GoType: CollectorAttribute 
-            Elem: &schema.Resource{
+			Type: schema.TypeList, //GoType: CollectorAttribute
+			Elem: &schema.Resource{
 				Schema: CollectorAttributeSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Required: true,
+			Required:   true,
 		},
-		
+
 		"data_points": {
-			Type: schema.TypeList, //GoType: []*DataPoint  
+			Type: schema.TypeList, //GoType: []*DataPoint
 			Elem: &schema.Resource{
 				Schema: DataPointSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"display_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"enable_auto_discovery": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_eri_discovery": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"eri_discovery_config": {
 			Type: schema.TypeList, //GoType: ScriptERIDiscoveryAttributeV2
 			Elem: &schema.Resource{
@@ -105,27 +105,27 @@ func DatasourceSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"eri_discovery_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"has_multi_instances": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"installation_metadata": {
 			Type: schema.TypeList, //GoType: IntegrationMetadata
 			Elem: &schema.Resource{
@@ -133,74 +133,72 @@ func DatasourceSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"lineage_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"payload_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"tags": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"technology": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"use_wild_value_as_uuid": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and DatasourceSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceDatasourceSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"access_group_ids": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"access_groups": {
-			Type: schema.TypeList, //GoType: []*AccessGroup 
+			Type: schema.TypeList, //GoType: []*AccessGroup
 			Elem: &schema.Resource{
 				Schema: AccessGroupSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"applies_to": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"audit_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"auto_discovery_config": {
 			Type: schema.TypeList, //GoType: AutoDiscoveryConfiguration
 			Elem: &schema.Resource{
@@ -208,22 +206,22 @@ func DataSourceDatasourceSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"checksum": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collect_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collect_method": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_attribute": {
 			Type: schema.TypeList, //GoType: CollectorAttribute
 			Elem: &schema.Resource{
@@ -231,36 +229,36 @@ func DataSourceDatasourceSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"data_points": {
-			Type: schema.TypeList, //GoType: []*DataPoint 
+			Type: schema.TypeList, //GoType: []*DataPoint
 			Elem: &schema.Resource{
 				Schema: DataPointSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"display_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"enable_auto_discovery": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_eri_discovery": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"eri_discovery_config": {
 			Type: schema.TypeList, //GoType: ScriptERIDiscoveryAttributeV2
 			Elem: &schema.Resource{
@@ -268,28 +266,28 @@ func DataSourceDatasourceSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"eri_discovery_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"has_multi_instances": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"installation_metadata": {
 			Type: schema.TypeList, //GoType: IntegrationMetadata
 			Elem: &schema.Resource{
@@ -297,45 +295,45 @@ func DataSourceDatasourceSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"lineage_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"payload_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"tags": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"technology": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"use_wild_value_as_uuid": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -409,13 +407,13 @@ func SetDatasourceSubResourceData(m []*models.Datasource) (d []*map[string]inter
 
 func DatasourceModel(d *schema.ResourceData) *models.Datasource {
 	accessGroupIds := utils.ConvertSetToInt32Slice(d.Get("access_group_ids").([]interface{}))
-     accessGroupsTempSlice := d.Get("access_groups").([]interface{})
-    accessGroups := []*models.AccessGroup{}
-    for _, val := range accessGroupsTempSlice {
-        if m, ok := val.(map[string]interface{}); ok {
-            accessGroups = append(accessGroups, AccessGroupModel(m))
-        }
-    }
+	accessGroupsTempSlice := d.Get("access_groups").([]interface{})
+	accessGroups := []*models.AccessGroup{}
+	for _, val := range accessGroupsTempSlice {
+		if m, ok := val.(map[string]interface{}); ok {
+			accessGroups = append(accessGroups, AccessGroupModel(m))
+		}
+	}
 	appliesTo := d.Get("applies_to").(string)
 	var autoDiscoveryConfig *models.AutoDiscoveryConfiguration = nil
 	autoDiscoveryConfigInterface, autoDiscoveryConfigIsSet := d.GetOk("auto_discovery_config")
@@ -449,28 +447,28 @@ func DatasourceModel(d *schema.ResourceData) *models.Datasource {
 	name := d.Get("name").(string)
 	tags := d.Get("tags").(string)
 	technology := d.Get("technology").(string)
-	
-	return &models.Datasource {
-		AccessGroupIds: accessGroupIds,
-		AccessGroups: accessGroups,
-		AppliesTo: appliesTo,
-		AutoDiscoveryConfig: autoDiscoveryConfig,
-		CollectInterval: &collectInterval,
-		CollectMethod: &collectMethod,
-		CollectorAttribute: collectorAttribute,
-		DataPoints: dataPoints,
-		Description: description,
-		DisplayName: displayName,
-		EnableAutoDiscovery: enableAutoDiscovery,
-		EnableEriDiscovery: enableEriDiscovery,
-		EriDiscoveryConfig: eriDiscoveryConfig,
+
+	return &models.Datasource{
+		AccessGroupIds:       accessGroupIds,
+		AccessGroups:         accessGroups,
+		AppliesTo:            appliesTo,
+		AutoDiscoveryConfig:  autoDiscoveryConfig,
+		CollectInterval:      &collectInterval,
+		CollectMethod:        &collectMethod,
+		CollectorAttribute:   collectorAttribute,
+		DataPoints:           dataPoints,
+		Description:          description,
+		DisplayName:          displayName,
+		EnableAutoDiscovery:  enableAutoDiscovery,
+		EnableEriDiscovery:   enableEriDiscovery,
+		EriDiscoveryConfig:   eriDiscoveryConfig,
 		EriDiscoveryInterval: eriDiscoveryInterval,
-		Group: group,
-		HasMultiInstances: hasMultiInstances,
-		ID: int32(id),
-		Name: &name,
-		Tags: tags,
-		Technology: technology,
+		Group:                group,
+		HasMultiInstances:    hasMultiInstances,
+		ID:                   int32(id),
+		Name:                 &name,
+		Tags:                 tags,
+		Technology:           technology,
 	}
 }
 func GetDatasourcePropertyFields() (t []string) {

--- a/logicmonitor/schemata/device_group_data_schema.go
+++ b/logicmonitor/schemata/device_group_data_schema.go
@@ -1,77 +1,76 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DeviceGroupDataSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"applies_to": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"aws_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"azure_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"gcp_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"group_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_hosts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -100,9 +99,8 @@ func SetDeviceGroupDataSubResourceData(m []*models.DeviceGroupData) (d []*map[st
 
 func DeviceGroupDataModel(d map[string]interface{}) *models.DeviceGroupData {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.DeviceGroupData {
-	}
+
+	return &models.DeviceGroupData{}
 }
 
 func GetDeviceGroupDataPropertyFields() (t []string) {

--- a/logicmonitor/schemata/device_group_pagination_response_schema.go
+++ b/logicmonitor/schemata/device_group_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DeviceGroupPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*DeviceGroup 
+			Type: schema.TypeList, //GoType: []*DeviceGroup
 			Elem: &schema.Resource{
 				Schema: DeviceGroupSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetDeviceGroupPaginationResponseSubResourceData(m []*models.DeviceGroupPagi
 func DeviceGroupPaginationResponseModel(d map[string]interface{}) *models.DeviceGroupPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.DeviceGroup)
-	
-	return &models.DeviceGroupPaginationResponse {
+
+	return &models.DeviceGroupPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/device_group_schema.go
+++ b/logicmonitor/schemata/device_group_schema.go
@@ -1,24 +1,24 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DeviceGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"applies_to": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"aws_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"aws_test_result": {
 			Type: schema.TypeList, //GoType: AwsAccountTestResult
 			Elem: &schema.Resource{
@@ -26,17 +26,17 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"aws_test_result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"azure_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"azure_test_result": {
 			Type: schema.TypeList, //GoType: AzureAccountTestResult
 			Elem: &schema.Resource{
@@ -44,61 +44,61 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"azure_test_result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"default_auto_balanced_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"default_collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"default_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"effective_alert_enabled": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"enable_netflow": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"extra": {
 			Type: schema.TypeList, //GoType: CloudAccountExtra
 			Elem: &schema.Resource{
@@ -106,17 +106,17 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"gcp_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"gcp_test_result": {
 			Type: schema.TypeList, //GoType: GcpAccountTestResult
 			Elem: &schema.Resource{
@@ -124,72 +124,72 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"gcp_test_result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"group_status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"group_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"has_netflow_enabled_devices": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"num_of_a_w_s_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_azure_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_gcp_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_hosts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"parent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"saas_test_result": {
 			Type: schema.TypeList, //GoType: SaasAccountTestResult
 			Elem: &schema.Resource{
@@ -197,39 +197,37 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"sub_groups": {
-			Type: schema.TypeList, //GoType: []*DeviceGroupData  
+			Type: schema.TypeList, //GoType: []*DeviceGroupData
 			Elem: &schema.Resource{
 				Schema: DeviceGroupDataSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Computed: true,
+			Computed:   true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and DeviceGroupSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceDeviceGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"applies_to": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"aws_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"aws_test_result": {
 			Type: schema.TypeList, //GoType: AwsAccountTestResult
 			Elem: &schema.Resource{
@@ -237,17 +235,17 @@ func DataSourceDeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"aws_test_result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"azure_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"azure_test_result": {
 			Type: schema.TypeList, //GoType: AzureAccountTestResult
 			Elem: &schema.Resource{
@@ -255,61 +253,61 @@ func DataSourceDeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"azure_test_result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"custom_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"default_auto_balanced_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"default_collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"default_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"effective_alert_enabled": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"enable_netflow": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"extra": {
 			Type: schema.TypeList, //GoType: CloudAccountExtra
 			Elem: &schema.Resource{
@@ -317,17 +315,17 @@ func DataSourceDeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"gcp_regions_info": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"gcp_test_result": {
 			Type: schema.TypeList, //GoType: GcpAccountTestResult
 			Elem: &schema.Resource{
@@ -335,73 +333,73 @@ func DataSourceDeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"gcp_test_result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group_status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"group_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"has_netflow_enabled_devices": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"num_of_a_w_s_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_azure_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_direct_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_gcp_devices": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_hosts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"parent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"saas_test_result": {
 			Type: schema.TypeList, //GoType: SaasAccountTestResult
 			Elem: &schema.Resource{
@@ -409,24 +407,24 @@ func DataSourceDeviceGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"sub_groups": {
-			Type: schema.TypeList, //GoType: []*DeviceGroupData 
+			Type: schema.TypeList, //GoType: []*DeviceGroupData
 			Elem: &schema.Resource{
 				Schema: DeviceGroupDataSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -534,20 +532,20 @@ func DeviceGroupModel(d *schema.ResourceData) *models.DeviceGroup {
 	id, _ := strconv.Atoi(d.Get("id").(string))
 	name := d.Get("name").(string)
 	parentID := int32(d.Get("parent_id").(int))
-	
-	return &models.DeviceGroup {
-		AppliesTo: appliesTo,
-		CustomProperties: customProperties,
+
+	return &models.DeviceGroup{
+		AppliesTo:                           appliesTo,
+		CustomProperties:                    customProperties,
 		DefaultAutoBalancedCollectorGroupID: defaultAutoBalancedCollectorGroupID,
-		DefaultCollectorID: defaultCollectorID,
-		Description: description,
-		DisableAlerting: disableAlerting,
-		EnableNetflow: enableNetflow,
-		Extra: extra,
-		GroupType: groupType,
-		ID: int32(id),
-		Name: &name,
-		ParentID: parentID,
+		DefaultCollectorID:                  defaultCollectorID,
+		Description:                         description,
+		DisableAlerting:                     disableAlerting,
+		EnableNetflow:                       enableNetflow,
+		Extra:                               extra,
+		GroupType:                           groupType,
+		ID:                                  int32(id),
+		Name:                                &name,
+		ParentID:                            parentID,
 	}
 }
 func GetDeviceGroupPropertyFields() (t []string) {

--- a/logicmonitor/schemata/device_pagination_response_schema.go
+++ b/logicmonitor/schemata/device_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DevicePaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*Device 
+			Type: schema.TypeList, //GoType: []*Device
 			Elem: &schema.Resource{
 				Schema: DeviceSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetDevicePaginationResponseSubResourceData(m []*models.DevicePaginationResp
 func DevicePaginationResponseModel(d map[string]interface{}) *models.DevicePaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.Device)
-	
-	return &models.DevicePaginationResponse {
+
+	return &models.DevicePaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/device_property_schema.go
+++ b/logicmonitor/schemata/device_property_schema.go
@@ -1,22 +1,21 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func DevicePropertySchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -36,9 +35,9 @@ func DevicePropertyModel(d map[string]interface{}) *models.DeviceProperty {
 	// assume that the incoming map only contains the relevant resource data
 	name := d["name"].(string)
 	value := d["value"].(string)
-	
-	return &models.DeviceProperty {
-		Name: &name,
+
+	return &models.DeviceProperty{
+		Name:  &name,
 		Value: &value,
 	}
 }

--- a/logicmonitor/schemata/device_schema.go
+++ b/logicmonitor/schemata/device_schema.go
@@ -1,540 +1,538 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DeviceSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"auto_balanced_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"auto_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Computed: true,
+			Computed:   true,
 		},
-		
+
 		"auto_props_assigned_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"auto_props_updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"aws_state": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"azure_state": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"contains_multi_value": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"current_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"current_log_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"deleted_time_in_ms": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_type": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"display_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"enable_netflow": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"gcp_state": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"host_group_ids": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"host_status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"inherited_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Computed: true,
+			Computed:   true,
 		},
-		
+
 		"is_preferred_log_collector_configured": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"last_data_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"last_rawdata_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"link": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"log_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"need_stc_grp_and_sorted_c_p": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"netflow_collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"netflow_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"netflow_collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"netflow_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"op": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"preferred_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"preferred_collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"preferred_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"related_device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"resource_ids": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"scan_config_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"synthetics_collector_ids": {
 			Type: schema.TypeList, //GoType: []int32
 			Elem: &schema.Schema{
-                 Type: schema.TypeInt,
-            },
+				Type: schema.TypeInt,
+			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"system_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Computed: true,
+			Computed:   true,
 		},
-		
+
 		"to_delete_time_in_ms": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"up_time_in_seconds": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and DeviceSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceDeviceSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"auto_balanced_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"auto_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"auto_props_assigned_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"auto_props_updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"aws_state": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"azure_state": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"contains_multi_value": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"created_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"current_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"current_log_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"custom_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"deleted_time_in_ms": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_type": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"display_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"enable_netflow": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"gcp_state": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"host_group_ids": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"host_status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"inherited_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"is_preferred_log_collector_configured": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"last_data_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"last_rawdata_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"link": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"log_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"need_stc_grp_and_sorted_c_p": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"netflow_collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"netflow_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"netflow_collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"netflow_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"op": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"preferred_collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"preferred_collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"preferred_collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"related_device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"resource_ids": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"scan_config_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"synthetics_collector_ids": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"system_properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"to_delete_time_in_ms": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"up_time_in_seconds": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"updated_on": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -675,31 +673,31 @@ func DeviceModel(d *schema.ResourceData) *models.Device {
 	relatedDeviceID := int32(d.Get("related_device_id").(int))
 	resourceIds := utils.GetPropertiesFromResource(d, "resource_ids")
 	syntheticsCollectorIds := utils.ConvertSetToInt32Slice(d.Get("synthetics_collector_ids").([]interface{}))
-	
-	return &models.Device {
-		AutoBalancedCollectorGroupID: autoBalancedCollectorGroupID,
-		ContainsMultiValue: containsMultiValue,
-		CurrentCollectorID: currentCollectorID,
-		CurrentLogCollectorID: currentLogCollectorID,
-		CustomProperties: customProperties,
-		Description: description,
-		DeviceType: deviceType,
-		DisableAlerting: disableAlerting,
-		DisplayName: &displayName,
-		EnableNetflow: enableNetflow,
-		HostGroupIds: hostGroupIds,
-		ID: int32(id),
+
+	return &models.Device{
+		AutoBalancedCollectorGroupID:      autoBalancedCollectorGroupID,
+		ContainsMultiValue:                containsMultiValue,
+		CurrentCollectorID:                currentCollectorID,
+		CurrentLogCollectorID:             currentLogCollectorID,
+		CustomProperties:                  customProperties,
+		Description:                       description,
+		DeviceType:                        deviceType,
+		DisableAlerting:                   disableAlerting,
+		DisplayName:                       &displayName,
+		EnableNetflow:                     enableNetflow,
+		HostGroupIds:                      hostGroupIds,
+		ID:                                int32(id),
 		IsPreferredLogCollectorConfigured: isPreferredLogCollectorConfigured,
-		Link: link,
-		LogCollectorID: logCollectorID,
-		Name: &name,
-		NeedStcGrpAndSortedCP: &needStcGrpAndSortedCP,
-		NetflowCollectorID: netflowCollectorID,
-		Op: op,
-		PreferredCollectorID: &preferredCollectorID,
-		RelatedDeviceID: relatedDeviceID,
-		ResourceIds: resourceIds,
-		SyntheticsCollectorIds: syntheticsCollectorIds,
+		Link:                              link,
+		LogCollectorID:                    logCollectorID,
+		Name:                              &name,
+		NeedStcGrpAndSortedCP:             &needStcGrpAndSortedCP,
+		NetflowCollectorID:                netflowCollectorID,
+		Op:                                op,
+		PreferredCollectorID:              &preferredCollectorID,
+		RelatedDeviceID:                   relatedDeviceID,
+		ResourceIds:                       resourceIds,
+		SyntheticsCollectorIds:            syntheticsCollectorIds,
 	}
 }
 func GetDevicePropertyFields() (t []string) {

--- a/logicmonitor/schemata/error_response_schema.go
+++ b/logicmonitor/schemata/error_response_schema.go
@@ -1,17 +1,17 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func ErrorResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"error_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"error_detail": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -19,12 +19,11 @@ func ErrorResponseSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		
+
 		"error_message": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -43,12 +42,10 @@ func SetErrorResponseSubResourceData(m []*models.ErrorResponse) (d []*map[string
 
 func ErrorResponseModel(d map[string]interface{}) *models.ErrorResponse {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.ErrorResponse {
-	}
+
+	return &models.ErrorResponse{}
 }
 
 func GetErrorResponsePropertyFields() (t []string) {
-	return []string{
-	}
+	return []string{}
 }

--- a/logicmonitor/schemata/escalation_chain_pagination_response_schema.go
+++ b/logicmonitor/schemata/escalation_chain_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func EscalationChainPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*EscalationChain  
+			Type: schema.TypeList, //GoType: []*EscalationChain
 			Elem: &schema.Resource{
 				Schema: EscalationChainSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetEscalationChainPaginationResponseSubResourceData(m []*models.EscalationC
 func EscalationChainPaginationResponseModel(d map[string]interface{}) *models.EscalationChainPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.EscalationChain)
-	
-	return &models.EscalationChainPaginationResponse {
+
+	return &models.EscalationChainPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/escalation_chain_schema.go
+++ b/logicmonitor/schemata/escalation_chain_schema.go
@@ -1,132 +1,130 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func EscalationChainSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"cc_destinations": {
-			Type: schema.TypeList, //GoType: []*Recipient  
+			Type: schema.TypeList, //GoType: []*Recipient
 			Elem: &schema.Resource{
 				Schema: RecipientSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"destinations": {
-			Type: schema.TypeList, //GoType: []*Chain  
+			Type: schema.TypeList, //GoType: []*Chain
 			Elem: &schema.Resource{
 				Schema: ChainSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Required: true,
+			Required:   true,
 		},
-		
+
 		"enable_throttling": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"in_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"throttling_alerts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"throttling_period": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and EscalationChainSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceEscalationChainSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"cc_destinations": {
-			Type: schema.TypeList, //GoType: []*Recipient 
+			Type: schema.TypeList, //GoType: []*Recipient
 			Elem: &schema.Resource{
 				Schema: RecipientSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"destinations": {
-			Type: schema.TypeList, //GoType: []*Chain 
+			Type: schema.TypeList, //GoType: []*Chain
 			Elem: &schema.Resource{
 				Schema: ChainSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"enable_throttling": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"in_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"throttling_alerts": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"throttling_period": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -165,20 +163,20 @@ func SetEscalationChainSubResourceData(m []*models.EscalationChain) (d []*map[st
 func EscalationChainModel(d *schema.ResourceData) *models.EscalationChain {
 	ccDestinations := utils.GetPropFromCCMap(d, "cc_destinations")
 	description := d.Get("description").(string)
-    destinations := utils.GetPropFromDesMap(d, "destinations")
+	destinations := utils.GetPropFromDesMap(d, "destinations")
 	enableThrottling := d.Get("enable_throttling").(bool)
 	id, _ := strconv.Atoi(d.Get("id").(string))
 	name := d.Get("name").(string)
 	throttlingAlerts := int32(d.Get("throttling_alerts").(int))
 	throttlingPeriod := int32(d.Get("throttling_period").(int))
-	
-	return &models.EscalationChain {
-		CcDestinations: ccDestinations,
-		Description: description,
-		Destinations: destinations,
+
+	return &models.EscalationChain{
+		CcDestinations:   ccDestinations,
+		Description:      description,
+		Destinations:     destinations,
 		EnableThrottling: enableThrottling,
-		ID: int32(id),
-		Name: &name,
+		ID:               int32(id),
+		Name:             &name,
 		ThrottlingAlerts: throttlingAlerts,
 		ThrottlingPeriod: throttlingPeriod,
 	}

--- a/logicmonitor/schemata/gcp_account_test_result_schema.go
+++ b/logicmonitor/schemata/gcp_account_test_result_schema.go
@@ -1,32 +1,31 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func GcpAccountTestResultSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"detail_link": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"no_permission_services": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"non_permission_errors": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -48,11 +47,11 @@ func GcpAccountTestResultModel(d map[string]interface{}) *models.GcpAccountTestR
 	detailLink := d["detail_link"].(string)
 	noPermissionServices := utils.ConvertSetToStringSlice(d["no_permission_services"].(*schema.Set))
 	nonPermissionErrors := utils.ConvertSetToStringSlice(d["non_permission_errors"].(*schema.Set))
-	
-	return &models.GcpAccountTestResult {
-		DetailLink: detailLink,
+
+	return &models.GcpAccountTestResult{
+		DetailLink:           detailLink,
 		NoPermissionServices: noPermissionServices,
-		NonPermissionErrors: nonPermissionErrors,
+		NonPermissionErrors:  nonPermissionErrors,
 	}
 }
 

--- a/logicmonitor/schemata/integration_metadata_schema.go
+++ b/logicmonitor/schemata/integration_metadata_schema.go
@@ -1,102 +1,101 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func IntegrationMetadataSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"audited_registry_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"audited_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"is_changed_from_origin": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"is_changed_from_target_last_published": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"local_module_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"logic_module_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_author_company_uuid": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_author_namespace": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_checksum": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_lineage_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_locator": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_registry_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"origin_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"target_last_published_checksum": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"target_last_published_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"target_last_published_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"target_lineage_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -130,12 +129,10 @@ func SetIntegrationMetadataSubResourceData(m []*models.IntegrationMetadata) (d [
 
 func IntegrationMetadataModel(d map[string]interface{}) *models.IntegrationMetadata {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.IntegrationMetadata {
-	}
+
+	return &models.IntegrationMetadata{}
 }
 
 func GetIntegrationMetadataPropertyFields() (t []string) {
-	return []string{
-	}
+	return []string{}
 }

--- a/logicmonitor/schemata/name_and_value_schema.go
+++ b/logicmonitor/schemata/name_and_value_schema.go
@@ -1,22 +1,21 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func NameAndValueSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -36,9 +35,9 @@ func NameAndValueModel(d map[string]interface{}) *models.NameAndValue {
 	// assume that the incoming map only contains the relevant resource data
 	name := d["name"].(string)
 	value := d["value"].(string)
-	
-	return &models.NameAndValue {
-		Name: &name,
+
+	return &models.NameAndValue{
+		Name:  &name,
 		Value: &value,
 	}
 }

--- a/logicmonitor/schemata/next_upgrade_info_schema.go
+++ b/logicmonitor/schemata/next_upgrade_info_schema.go
@@ -1,42 +1,41 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func NextUpgradeInfoSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"major_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"mandatory": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"minor_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"stable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"upgrade_time": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"upgrade_time_epoch": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -58,12 +57,10 @@ func SetNextUpgradeInfoSubResourceData(m []*models.NextUpgradeInfo) (d []*map[st
 
 func NextUpgradeInfoModel(d map[string]interface{}) *models.NextUpgradeInfo {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.NextUpgradeInfo {
-	}
+
+	return &models.NextUpgradeInfo{}
 }
 
 func GetNextUpgradeInfoPropertyFields() (t []string) {
-	return []string{
-	}
+	return []string{}
 }

--- a/logicmonitor/schemata/onetime_upgrade_info_schema.go
+++ b/logicmonitor/schemata/onetime_upgrade_info_schema.go
@@ -1,57 +1,56 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func OnetimeUpgradeInfoSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"created_by": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"end_epoch": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"level": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"major_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"minor_version": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"start_epoch": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"timezone": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -81,13 +80,13 @@ func OnetimeUpgradeInfoModel(d map[string]interface{}) *models.OnetimeUpgradeInf
 	minorVersion := int32(d["minor_version"].(int))
 	startEpoch := int64(d["start_epoch"].(int))
 	timezone := d["timezone"].(string)
-	
-	return &models.OnetimeUpgradeInfo {
-		Description: description,
+
+	return &models.OnetimeUpgradeInfo{
+		Description:  description,
 		MajorVersion: &majorVersion,
 		MinorVersion: &minorVersion,
-		StartEpoch: &startEpoch,
-		Timezone: timezone,
+		StartEpoch:   &startEpoch,
+		Timezone:     timezone,
 	}
 }
 

--- a/logicmonitor/schemata/period_schema.go
+++ b/logicmonitor/schemata/period_schema.go
@@ -1,37 +1,36 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func PeriodSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"end_minutes": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"start_minutes": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Required: true,
 		},
-		
+
 		"timezone": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"week_days": {
 			Type: schema.TypeList, //GoType: []int32
 			Elem: &schema.Schema{
-                 Type: schema.TypeInt,
-            },
+				Type: schema.TypeInt,
+			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Required: true,
+			Required:   true,
 		},
-		
 	}
 }
 
@@ -55,12 +54,12 @@ func PeriodModel(d map[string]interface{}) *models.Period {
 	startMinutes := int32(d["start_minutes"].(int))
 	timezone := d["timezone"].(string)
 	weekDays := utils.ConvertSetToInt32Slice(d["weekDays"].([]interface{}))
-	
-	return &models.Period {
-		EndMinutes: &endMinutes,
+
+	return &models.Period{
+		EndMinutes:   &endMinutes,
 		StartMinutes: &startMinutes,
-		Timezone: &timezone,
-		WeekDays: weekDays,
+		Timezone:     &timezone,
+		WeekDays:     weekDays,
 	}
 }
 

--- a/logicmonitor/schemata/recipient_schema.go
+++ b/logicmonitor/schemata/recipient_schema.go
@@ -1,32 +1,31 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func RecipientSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"addr": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"contact": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"method": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -50,12 +49,12 @@ func RecipientModel(d map[string]interface{}) *models.Recipient {
 	contact := d["contact"].(string)
 	method := d["method"].(string)
 	typeVar := d["type"].(string)
-	
-	return &models.Recipient {
-		Addr: addr,
+
+	return &models.Recipient{
+		Addr:    addr,
 		Contact: contact,
-		Method: &method,
-		Type: &typeVar,
+		Method:  &method,
+		Type:    &typeVar,
 	}
 }
 

--- a/logicmonitor/schemata/rest_highest_priority_collector_status_schema.go
+++ b/logicmonitor/schemata/rest_highest_priority_collector_status_schema.go
@@ -1,32 +1,31 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func RestHighestPriorityCollectorStatusSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"acked": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"in_s_d_t": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"is_down": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -46,12 +45,10 @@ func SetRestHighestPriorityCollectorStatusSubResourceData(m []*models.RestHighes
 
 func RestHighestPriorityCollectorStatusModel(d map[string]interface{}) *models.RestHighestPriorityCollectorStatus {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.RestHighestPriorityCollectorStatus {
-	}
+
+	return &models.RestHighestPriorityCollectorStatus{}
 }
 
 func GetRestHighestPriorityCollectorStatusPropertyFields() (t []string) {
-	return []string{
-	}
+	return []string{}
 }

--- a/logicmonitor/schemata/saas_account_test_result_schema.go
+++ b/logicmonitor/schemata/saas_account_test_result_schema.go
@@ -1,47 +1,46 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func SaasAccountTestResultSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"detail_link": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"invalid_status_urls": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"no_permission_apis": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"no_permission_service": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"non_permission_apis_errors": {
-			Type: schema.TypeSet,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 			Optional: true,
 		},
-		
+
 		"result_code": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -69,14 +68,14 @@ func SaasAccountTestResultModel(d map[string]interface{}) *models.SaasAccountTes
 	noPermissionService := d["no_permission_service"].(string)
 	nonPermissionApisErrors := utils.ConvertSetToStringSlice(d["non_permission_apis_errors"].(*schema.Set))
 	resultCode := int32(d["result_code"].(int))
-	
-	return &models.SaasAccountTestResult {
-		DetailLink: detailLink,
-		InvalidStatusUrls: invalidStatusUrls,
-		NoPermissionApis: noPermissionApis,
-		NoPermissionService: noPermissionService,
+
+	return &models.SaasAccountTestResult{
+		DetailLink:              detailLink,
+		InvalidStatusUrls:       invalidStatusUrls,
+		NoPermissionApis:        noPermissionApis,
+		NoPermissionService:     noPermissionService,
 		NonPermissionApisErrors: nonPermissionApisErrors,
-		ResultCode: resultCode,
+		ResultCode:              resultCode,
 	}
 }
 

--- a/logicmonitor/schemata/script_e_r_i_discovery_attribute_v2_schema.go
+++ b/logicmonitor/schemata/script_e_r_i_discovery_attribute_v2_schema.go
@@ -1,47 +1,46 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func ScriptERIDiscoveryAttributeV2Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"groovy_script": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"linux_cmdline": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"linux_script": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"win_cmdline": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"win_script": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
 	}
 }
 
@@ -71,15 +70,15 @@ func ScriptERIDiscoveryAttributeV2Model(d map[string]interface{}) *models.Script
 	typeVar := d["type"].(string)
 	winCmdline := d["win_cmdline"].(string)
 	winScript := d["win_script"].(string)
-	
-	return &models.ScriptERIDiscoveryAttributeV2 {
+
+	return &models.ScriptERIDiscoveryAttributeV2{
 		GroovyScript: groovyScript,
 		LinuxCmdline: linuxCmdline,
-		LinuxScript: linuxScript,
-		Name: &name,
-		Type: typeVar,
-		WinCmdline: winCmdline,
-		WinScript: winScript,
+		LinuxScript:  linuxScript,
+		Name:         &name,
+		Type:         typeVar,
+		WinCmdline:   winCmdline,
+		WinScript:    winScript,
 	}
 }
 

--- a/logicmonitor/schemata/sdt_pagination_response_schema.go
+++ b/logicmonitor/schemata/sdt_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func SdtPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*Sdt  
+			Type: schema.TypeList, //GoType: []*Sdt
 			Elem: &schema.Resource{
 				Schema: SdtSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetSdtPaginationResponseSubResourceData(m []*models.SdtPaginationResponse) 
 func SdtPaginationResponseModel(d map[string]interface{}) *models.SdtPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.Sdt)
-	
-	return &models.SdtPaginationResponse {
+
+	return &models.SdtPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/sdt_schema.go
+++ b/logicmonitor/schemata/sdt_schema.go
@@ -2,394 +2,392 @@ package schemata
 
 import (
 	"github.com/go-openapi/strfmt"
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func SdtSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"admin": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"batch_job_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"comment": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"data_source_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"data_source_instance_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"data_source_instance_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"data_source_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"default_value": {
-			Type: schema.TypeString, //GoType: strfmt.DateTime
+			Type:     schema.TypeString, //GoType: strfmt.DateTime
 			Optional: true,
 		},
-		
+
 		"device_batch_job_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_data_source_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_data_source_instance_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_data_source_instance_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_display_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_event_source_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_group_full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"duration": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"end_date_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"end_date_time_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"end_hour": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"end_minute": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"event_source_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"hour": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"is_effective": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"minute": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"month_day": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"sdt_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"start_date_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"start_date_time_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"timezone": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"week_day": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"week_of_month": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and SdtSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceSdtSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"admin": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"batch_job_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"collector_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"comment": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"data_source_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"data_source_instance_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"data_source_instance_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"data_source_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"default_value": {
-			Type: schema.TypeString, //GoType: strfmt.DateTime
+			Type:     schema.TypeString, //GoType: strfmt.DateTime
 			Optional: true,
 		},
-		
+
 		"device_batch_job_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_data_source_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_data_source_instance_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_data_source_instance_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_display_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_event_source_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_group_full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"device_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"device_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"duration": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"end_date_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"end_date_time_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"end_hour": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"end_minute": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"event_source_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"hour": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"is_effective": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"minute": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"month_day": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"sdt_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"start_date_time": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"start_date_time_on_local": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"timezone": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"week_day": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"week_of_month": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -515,40 +513,40 @@ func SdtModel(d *schema.ResourceData) *models.Sdt {
 	typeVar := d.Get("type").(string)
 	weekDay := d.Get("week_day").(string)
 	weekOfMonth := d.Get("week_of_month").(string)
-	
-	return &models.Sdt {
-		BatchJobName: batchJobName,
-		CollectorID: collectorID,
-		Comment: comment,
-		DataSourceID: dataSourceID,
-		DataSourceInstanceID: dataSourceInstanceID,
-		DataSourceInstanceName: dataSourceInstanceName,
-		DataSourceName: dataSourceName,
-		DefaultValue: defaultValue,
-		DeviceBatchJobID: deviceBatchJobID,
-		DeviceDataSourceID: deviceDataSourceID,
-		DeviceDataSourceInstanceGroupID: deviceDataSourceInstanceGroupID,
+
+	return &models.Sdt{
+		BatchJobName:                      batchJobName,
+		CollectorID:                       collectorID,
+		Comment:                           comment,
+		DataSourceID:                      dataSourceID,
+		DataSourceInstanceID:              dataSourceInstanceID,
+		DataSourceInstanceName:            dataSourceInstanceName,
+		DataSourceName:                    dataSourceName,
+		DefaultValue:                      defaultValue,
+		DeviceBatchJobID:                  deviceBatchJobID,
+		DeviceDataSourceID:                deviceDataSourceID,
+		DeviceDataSourceInstanceGroupID:   deviceDataSourceInstanceGroupID,
 		DeviceDataSourceInstanceGroupName: deviceDataSourceInstanceGroupName,
-		DeviceDisplayName: deviceDisplayName,
-		DeviceEventSourceID: deviceEventSourceID,
-		DeviceGroupFullPath: deviceGroupFullPath,
-		DeviceGroupID: deviceGroupID,
-		DeviceID: deviceID,
-		Duration: duration,
-		EndDateTime: endDateTime,
-		EndHour: endHour,
-		EndMinute: endMinute,
-		EventSourceName: eventSourceName,
-		Hour: hour,
-		ID: id,
-		Minute: minute,
-		MonthDay: monthDay,
-		SdtType: sdtType,
-		StartDateTime: startDateTime,
-		Timezone: timezone,
-		Type: &typeVar,
-		WeekDay: weekDay,
-		WeekOfMonth: weekOfMonth,
+		DeviceDisplayName:                 deviceDisplayName,
+		DeviceEventSourceID:               deviceEventSourceID,
+		DeviceGroupFullPath:               deviceGroupFullPath,
+		DeviceGroupID:                     deviceGroupID,
+		DeviceID:                          deviceID,
+		Duration:                          duration,
+		EndDateTime:                       endDateTime,
+		EndHour:                           endHour,
+		EndMinute:                         endMinute,
+		EventSourceName:                   eventSourceName,
+		Hour:                              hour,
+		ID:                                id,
+		Minute:                            minute,
+		MonthDay:                          monthDay,
+		SdtType:                           sdtType,
+		StartDateTime:                     startDateTime,
+		Timezone:                          timezone,
+		Type:                              &typeVar,
+		WeekDay:                           weekDay,
+		WeekOfMonth:                       weekOfMonth,
 	}
 }
 func GetSdtPropertyFields() (t []string) {

--- a/logicmonitor/schemata/web_check_step_schema.go
+++ b/logicmonitor/schemata/web_check_step_schema.go
@@ -1,151 +1,150 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func WebCheckStepSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"http_body": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"http_headers": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"http_method": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"http_version": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"auth": {
-			Type: schema.TypeList, //GoType: Authentication 
-            Elem: &schema.Resource{
+			Type: schema.TypeList, //GoType: Authentication
+			Elem: &schema.Resource{
 				Schema: AuthenticationSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"enable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"follow_redirection": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"fullpage_load": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"invert_match": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"keyword": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"label": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"match_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"post_data_edit_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"req_script": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"req_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"require_auth": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"resp_script": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"resp_type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"schema": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"status_code": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"timeout": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"url": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"use_default_root": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Required: true,
 		},
-		
 	}
 }
 
@@ -219,35 +218,35 @@ func WebCheckStepModel(d map[string]interface{}) *models.WebCheckStep {
 	typeVar := d["type"].(string)
 	url := d["url"].(string)
 	useDefaultRoot := d["use_default_root"].(bool)
-	
-	return &models.WebCheckStep {
-		HTTPBody: hTTPBody,
-		HTTPHeaders: hTTPHeaders,
-		HTTPMethod: hTTPMethod,
-		HTTPVersion: hTTPVersion,
-		Auth: auth,
-		Description: description,
-		Enable: enable,
+
+	return &models.WebCheckStep{
+		HTTPBody:          hTTPBody,
+		HTTPHeaders:       hTTPHeaders,
+		HTTPMethod:        hTTPMethod,
+		HTTPVersion:       hTTPVersion,
+		Auth:              auth,
+		Description:       description,
+		Enable:            enable,
 		FollowRedirection: followRedirection,
-		FullpageLoad: fullpageLoad,
-		InvertMatch: invertMatch,
-		Keyword: keyword,
-		Label: label,
-		MatchType: matchType,
-		Name: name,
-		Path: path,
-		PostDataEditType: postDataEditType,
-		ReqScript: reqScript,
-		ReqType: reqType,
-		RequireAuth: requireAuth,
-		RespScript: respScript,
-		RespType: respType,
-		Schema: schema,
-		StatusCode: statusCode,
-		Timeout: timeout,
-		Type: typeVar,
-		URL: url,
-		UseDefaultRoot: &useDefaultRoot,
+		FullpageLoad:      fullpageLoad,
+		InvertMatch:       invertMatch,
+		Keyword:           keyword,
+		Label:             label,
+		MatchType:         matchType,
+		Name:              name,
+		Path:              path,
+		PostDataEditType:  postDataEditType,
+		ReqScript:         reqScript,
+		ReqType:           reqType,
+		RequireAuth:       requireAuth,
+		RespScript:        respScript,
+		RespType:          respType,
+		Schema:            schema,
+		StatusCode:        statusCode,
+		Timeout:           timeout,
+		Type:              typeVar,
+		URL:               url,
+		UseDefaultRoot:    &useDefaultRoot,
 	}
 }
 

--- a/logicmonitor/schemata/website_collector_info_schema.go
+++ b/logicmonitor/schemata/website_collector_info_schema.go
@@ -1,42 +1,41 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func WebsiteCollectorInfoSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"collector_group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"collector_group_name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"hostname": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -58,9 +57,8 @@ func SetWebsiteCollectorInfoSubResourceData(m []*models.WebsiteCollectorInfo) (d
 
 func WebsiteCollectorInfoModel(d map[string]interface{}) *models.WebsiteCollectorInfo {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.WebsiteCollectorInfo {
-	}
+
+	return &models.WebsiteCollectorInfo{}
 }
 
 func GetWebsiteCollectorInfoPropertyFields() (t []string) {

--- a/logicmonitor/schemata/website_group_pagination_response_schema.go
+++ b/logicmonitor/schemata/website_group_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func WebsiteGroupPaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*WebsiteGroup  
+			Type: schema.TypeList, //GoType: []*WebsiteGroup
 			Elem: &schema.Resource{
 				Schema: WebsiteGroupSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetWebsiteGroupPaginationResponseSubResourceData(m []*models.WebsiteGroupPa
 func WebsiteGroupPaginationResponseModel(d map[string]interface{}) *models.WebsiteGroupPaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.WebsiteGroup)
-	
-	return &models.WebsiteGroupPaginationResponse {
+
+	return &models.WebsiteGroupPaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/website_group_schema.go
+++ b/logicmonitor/schemata/website_group_schema.go
@@ -1,165 +1,163 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func WebsiteGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"has_websites_disabled": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_direct_websites": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"num_of_websites": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"parent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"stop_monitoring": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"test_location": {
-			Type: schema.TypeList, //GoType: WebsiteLocation 
-            Elem: &schema.Resource{
+			Type: schema.TypeList, //GoType: WebsiteLocation
+			Elem: &schema.Resource{
 				Schema: WebsiteLocationSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and WebsiteGroupSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceWebsiteGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"full_path": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"has_websites_disabled": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"num_of_direct_sub_groups": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_direct_websites": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"num_of_websites": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"parent_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"properties": {
-			Type: schema.TypeList, //GoType: []*NameAndValue 
+			Type: schema.TypeList, //GoType: []*NameAndValue
 			Elem: &schema.Resource{
 				Schema: NameAndValueSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"stop_monitoring": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"test_location": {
 			Type: schema.TypeList, //GoType: WebsiteLocation
 			Elem: &schema.Resource{
@@ -167,15 +165,15 @@ func DataSourceWebsiteGroupSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -229,19 +227,17 @@ func WebsiteGroupModel(d *schema.ResourceData) *models.WebsiteGroup {
 	parentID := int32(d.Get("parent_id").(int))
 	properties := utils.GetPropertiesFromResource(d, "properties")
 	stopMonitoring := d.Get("stop_monitoring").(bool)
-    testLocation := utils.GetPropFromLocationMap(d, "test_location")
+	testLocation := utils.GetPropFromLocationMap(d, "test_location")
 
-	          
-	
-	return &models.WebsiteGroup {
-		Description: description,
+	return &models.WebsiteGroup{
+		Description:     description,
 		DisableAlerting: disableAlerting,
-		ID: int32(id),
-		Name: &name,
-		ParentID: parentID,
-		Properties: properties,
-		StopMonitoring: stopMonitoring,
-		TestLocation: testLocation,
+		ID:              int32(id),
+		Name:            &name,
+		ParentID:        parentID,
+		Properties:      properties,
+		StopMonitoring:  stopMonitoring,
+		TestLocation:    testLocation,
 	}
 }
 func GetWebsiteGroupPropertyFields() (t []string) {

--- a/logicmonitor/schemata/website_location_schema.go
+++ b/logicmonitor/schemata/website_location_schema.go
@@ -1,45 +1,44 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func WebsiteLocationSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"all": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"collector_ids": {
 			Type: schema.TypeList, //GoType: []int32
 			Elem: &schema.Schema{
-                 Type: schema.TypeInt,
-            },
+				Type: schema.TypeInt,
+			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"collectors": {
-			Type: schema.TypeList, //GoType: []*WebsiteCollectorInfo  
+			Type: schema.TypeList, //GoType: []*WebsiteCollectorInfo
 			Elem: &schema.Resource{
 				Schema: WebsiteCollectorInfoSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"smg_ids": {
 			Type: schema.TypeList, //GoType: []int32
 			Elem: &schema.Schema{
-                 Type: schema.TypeInt,
-            },
+				Type: schema.TypeInt,
+			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
 	}
 }
 
@@ -63,12 +62,12 @@ func WebsiteLocationModel(d map[string]interface{}) *models.WebsiteLocation {
 	collectorIds := utils.ConvertSetToInt32Slice(d["collectorIds"].([]interface{}))
 	collectors := d["collectors"].([]*models.WebsiteCollectorInfo)
 	smgIds := utils.ConvertSetToInt32Slice(d["smgIds"].([]interface{}))
-	
-	return &models.WebsiteLocation {
-		All: all,
+
+	return &models.WebsiteLocation{
+		All:          all,
 		CollectorIds: collectorIds,
-		Collectors: collectors,
-		SmgIds: smgIds,
+		Collectors:   collectors,
+		SmgIds:       smgIds,
 	}
 }
 

--- a/logicmonitor/schemata/website_pagination_response_schema.go
+++ b/logicmonitor/schemata/website_pagination_response_schema.go
@@ -1,31 +1,30 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func WebsitePaginationResponseSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"items": {
-			Type: schema.TypeList, //GoType: []*Website  
+			Type: schema.TypeList, //GoType: []*Website
 			Elem: &schema.Resource{
 				Schema: WebsiteSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"search_id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"total": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -45,8 +44,8 @@ func SetWebsitePaginationResponseSubResourceData(m []*models.WebsitePaginationRe
 func WebsitePaginationResponseModel(d map[string]interface{}) *models.WebsitePaginationResponse {
 	// assume that the incoming map only contains the relevant resource data
 	items := d["items"].([]*models.Website)
-	
-	return &models.WebsitePaginationResponse {
+
+	return &models.WebsitePaginationResponse{
 		Items: items,
 	}
 }

--- a/logicmonitor/schemata/website_schema.go
+++ b/logicmonitor/schemata/website_schema.go
@@ -1,123 +1,123 @@
 package schemata
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strconv"
 	"terraform-provider-logicmonitor/logicmonitor/utils"
 	"terraform-provider-logicmonitor/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func WebsiteSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"alert_expr": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"domain": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"global_sm_alert_cond": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"host": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"ignore_s_s_l": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"individual_alert_level": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"individual_sm_alert_enable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"is_internal": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"last_updated": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"overall_alert_level": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"polling_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"schema": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"steps": {
-			Type: schema.TypeList, //GoType: []*WebCheckStep  
+			Type: schema.TypeList, //GoType: []*WebCheckStep
 			Elem: &schema.Resource{
 				Schema: WebCheckStepSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"stop_monitoring": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"stop_monitoring_by_folder": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"template": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -125,169 +125,167 @@ func WebsiteSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"test_location": {
-			Type: schema.TypeList, //GoType: WebsiteLocation 
-            Elem: &schema.Resource{
+			Type: schema.TypeList, //GoType: WebsiteLocation
+			Elem: &schema.Resource{
 				Schema: WebsiteLocationSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"transition": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"trigger_s_s_l_expiration_alert": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"trigger_s_s_l_status_alert": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
 		},
-		
+
 		"use_default_alert_setting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"use_default_location_setting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
 	}
 }
-
 
 // Schema mapping representing the resource's respective datasource object defined in Terraform configuration
 // Only difference between this and WebsiteSchema() are the computabilty of the id field and the inclusion of a filter field for datasources
 func DataSourceWebsiteSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"alert_expr": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"description": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"disable_alerting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"domain": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"global_sm_alert_cond": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"group_id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"host": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"id": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Computed: true,
 			Optional: true,
 		},
-		
+
 		"ignore_s_s_l": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"individual_alert_level": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"individual_sm_alert_enable": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"is_internal": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"last_updated": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"name": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"overall_alert_level": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"polling_interval": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"schema": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"status": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"steps": {
-			Type: schema.TypeList, //GoType: []*WebCheckStep 
+			Type: schema.TypeList, //GoType: []*WebCheckStep
 			Elem: &schema.Resource{
 				Schema: WebCheckStepSchema(),
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:   true,
 		},
-		
+
 		"stop_monitoring": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"stop_monitoring_by_folder": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"template": {
 			Type: schema.TypeMap, //GoType: interface{}
 			Elem: &schema.Schema{
@@ -295,7 +293,7 @@ func DataSourceWebsiteSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"test_location": {
 			Type: schema.TypeList, //GoType: WebsiteLocation
 			Elem: &schema.Resource{
@@ -303,45 +301,45 @@ func DataSourceWebsiteSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-		
+
 		"transition": {
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"trigger_s_s_l_expiration_alert": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"trigger_s_s_l_status_alert": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"type": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"use_default_alert_setting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"use_default_location_setting": {
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"user_permission": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 		},
-		
+
 		"filter": {
 			Type:     schema.TypeString,
-            Optional: true,
+			Optional: true,
 		},
 	}
 }
@@ -439,7 +437,7 @@ func WebsiteModel(d *schema.ResourceData) *models.Website {
 	steps := utils.GetPropFromSteps(d, "steps")
 	stopMonitoring := d.Get("stop_monitoring").(bool)
 	template := d.Get("template")
-    testLocation := utils.GetPropFromLocationMap(d, "test_location")
+	testLocation := utils.GetPropFromLocationMap(d, "test_location")
 	transition := int32(d.Get("transition").(int))
 	triggerSSLExpirationAlert := d.Get("trigger_s_s_l_expiration_alert").(bool)
 	triggerSSLStatusAlert := d.Get("trigger_s_s_l_status_alert").(bool)
@@ -447,35 +445,35 @@ func WebsiteModel(d *schema.ResourceData) *models.Website {
 	useDefaultAlertSetting := d.Get("use_default_alert_setting").(bool)
 	useDefaultLocationSetting := d.Get("use_default_location_setting").(bool)
 	userPermission := d.Get("user_permission").(string)
-	
-	return &models.Website {
-		AlertExpr: alertExpr,
-		Description: description,
-		DisableAlerting: disableAlerting,
-		Domain: domain,
-		GlobalSmAlertCond: globalSmAlertCond,
-		GroupID: groupID,
-		Host: host,
-		ID: int32(id),
-		IgnoreSSL: ignoreSSL,
-		IndividualAlertLevel: individualAlertLevel,
-		IndividualSmAlertEnable: individualSmAlertEnable,
-		IsInternal: isInternal,
-		Name: &name,
-		OverallAlertLevel: overallAlertLevel,
-		PollingInterval: pollingInterval,
-		Schema: schema,
-		Steps: steps,
-		StopMonitoring: stopMonitoring,
-		Template: template,
-		TestLocation: testLocation,
-		Transition: transition,
+
+	return &models.Website{
+		AlertExpr:                 alertExpr,
+		Description:               description,
+		DisableAlerting:           disableAlerting,
+		Domain:                    domain,
+		GlobalSmAlertCond:         globalSmAlertCond,
+		GroupID:                   groupID,
+		Host:                      host,
+		ID:                        int32(id),
+		IgnoreSSL:                 ignoreSSL,
+		IndividualAlertLevel:      individualAlertLevel,
+		IndividualSmAlertEnable:   individualSmAlertEnable,
+		IsInternal:                isInternal,
+		Name:                      &name,
+		OverallAlertLevel:         overallAlertLevel,
+		PollingInterval:           pollingInterval,
+		Schema:                    schema,
+		Steps:                     steps,
+		StopMonitoring:            stopMonitoring,
+		Template:                  template,
+		TestLocation:              testLocation,
+		Transition:                transition,
 		TriggerSSLExpirationAlert: triggerSSLExpirationAlert,
-		TriggerSSLStatusAlert: triggerSSLStatusAlert,
-		Type: &typeVar,
-		UseDefaultAlertSetting: useDefaultAlertSetting,
+		TriggerSSLStatusAlert:     triggerSSLStatusAlert,
+		Type:                      &typeVar,
+		UseDefaultAlertSetting:    useDefaultAlertSetting,
 		UseDefaultLocationSetting: useDefaultLocationSetting,
-		UserPermission: userPermission,
+		UserPermission:            userPermission,
 	}
 }
 func GetWebsitePropertyFields() (t []string) {

--- a/logicmonitor/schemata/widget_token_inheritance_schema.go
+++ b/logicmonitor/schemata/widget_token_inheritance_schema.go
@@ -1,22 +1,21 @@
 package schemata
 
 import (
-	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"terraform-provider-logicmonitor/models"
 )
 
 func WidgetTokenInheritanceSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"fullpath": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
-		
 	}
 }
 
@@ -34,12 +33,10 @@ func SetWidgetTokenInheritanceSubResourceData(m []*models.WidgetTokenInheritance
 
 func WidgetTokenInheritanceModel(d map[string]interface{}) *models.WidgetTokenInheritance {
 	// assume that the incoming map only contains the relevant resource data
-	
-	return &models.WidgetTokenInheritance {
-	}
+
+	return &models.WidgetTokenInheritance{}
 }
 
 func GetWidgetTokenInheritancePropertyFields() (t []string) {
-	return []string{
-	}
+	return []string{}
 }

--- a/logicmonitor/schemata/widget_token_schema.go
+++ b/logicmonitor/schemata/widget_token_schema.go
@@ -53,11 +53,11 @@ func WidgetTokenModel(d map[string]interface{}) *models.WidgetToken {
 	inheritList := d["inherit_list"].([]*models.WidgetTokenInheritance)
 	name := d["name"].(string)
 	value := d["value"].(string)
-	
-	return &models.WidgetToken {
+
+	return &models.WidgetToken{
 		InheritList: inheritList,
-		Name: name,
-		Value: value,
+		Name:        name,
+		Value:       value,
 	}
 }
 

--- a/logicmonitor/utils/helper_functions.go
+++ b/logicmonitor/utils/helper_functions.go
@@ -130,6 +130,7 @@ func getPropertiesFromInterface(r interface{}) (t []*models.NameAndValue) {
 	}
 	return
 }
+
 // retrieve resource custom properties (techops version - json object input)
 func GetPropertiesTechops(d *schema.ResourceData) (t []*models.NameAndValue) {
 	// interate through hashmap to get custom/system properties
@@ -194,15 +195,15 @@ func GetCloudTagFilters(d []interface{}) (t []*models.CloudTagFilter) {
 	}
 	return
 }
-func GetResourceProperties(d []interface{}) (t []*models.DeviceProperty ) {
+func GetResourceProperties(d []interface{}) (t []*models.DeviceProperty) {
 	for _, i := range d {
 		if m, ok := i.(map[string]interface{}); ok {
 			var name = m["name"].(string)
 			var value = m["value"].(string)
 
 			model := &models.DeviceProperty{
-				Name:      &name,
-				Value:     &value,
+				Name:  &name,
+				Value: &value,
 			}
 			t = append(t, model)
 		}
@@ -246,15 +247,15 @@ func getPropFromWTInterface(r interface{}) (t []*models.WidgetToken) {
 }
 
 func ConvertSetToInt32Slice(set interface{}) (slice []int32) {
-    if set == nil {
-        return
-    }
-    setList := set.([]interface{})
-    slice = make([]int32, len(setList))
-    for i, v := range setList {
-        slice[i] = int32(v.(int))
-    }
-    return slice
+	if set == nil {
+		return
+	}
+	setList := set.([]interface{})
+	slice = make([]int32, len(setList))
+	for i, v := range setList {
+		slice[i] = int32(v.(int))
+	}
+	return slice
 }
 
 func GetPropFromCCMap(d *schema.ResourceData, key string) (t []*models.Recipient) {
@@ -279,10 +280,10 @@ func getPropFromCCInterface(r interface{}) (t []*models.Recipient) {
 			var Type = m["type"].(string)
 
 			model := &models.Recipient{
-				Addr:  addr,
+				Addr:    addr,
 				Contact: contact,
-				Method: &method,
-                Type: &Type,
+				Method:  &method,
+				Type:    &Type,
 			}
 			t = append(t, model)
 		}
@@ -291,24 +292,23 @@ func getPropFromCCInterface(r interface{}) (t []*models.Recipient) {
 }
 
 func getPropFromDesInterface(r interface{}) (t []*models.Chain) {
-    
 
-    for _, i := range r.([]interface{}) {
-    if m, ok := i.(map[string]interface{}); ok {
-      var period = GetPeriod(m["period"].([]interface{}))
-		var stages =  GetRecipient(m["stages"].([]interface{}))
-		var Type = m["type"].(string)
-            
-            model := &models.Chain{
-                Period: &period,
-                Stages: stages,
-				Type: &Type,
-            }
-            t = append(t, model)
-        }
-    }
+	for _, i := range r.([]interface{}) {
+		if m, ok := i.(map[string]interface{}); ok {
+			var period = GetPeriod(m["period"].([]interface{}))
+			var stages = GetRecipient(m["stages"].([]interface{}))
+			var Type = m["type"].(string)
 
-    return 
+			model := &models.Chain{
+				Period: &period,
+				Stages: stages,
+				Type:   &Type,
+			}
+			t = append(t, model)
+		}
+	}
+
+	return
 }
 func GetRecipient(d []interface{}) (t [][]*models.Recipient) {
 	for _, stageData := range d {
@@ -345,13 +345,13 @@ func GetPeriod(d []interface{}) (t models.Period) {
 			var endMinutes = int32(m["end_minutes"].(int))
 			var startMinutes = int32(m["start_minutes"].(int))
 			var timezone = m["timezone"].(string)
-            var weekDays = ConvertSetToInt32Slice(m["week_days"])
-			
+			var weekDays = ConvertSetToInt32Slice(m["week_days"])
+
 			model := models.Period{
-				EndMinutes: &endMinutes,
+				EndMinutes:   &endMinutes,
 				StartMinutes: &startMinutes,
-				Timezone: &timezone,
-			    WeekDays: weekDays,
+				Timezone:     &timezone,
+				WeekDays:     weekDays,
 			}
 			t = model
 		}
@@ -371,7 +371,7 @@ func getPropFromStepsInterface(r interface{}) (t []*models.WebCheckStep) {
 		if m, ok := i.(map[string]interface{}); ok {
 			var schema = m["schema"].(string)
 			var matchType = m["match_type"].(string)
-            var description = m["description"].(string)
+			var description = m["description"].(string)
 			var httpVersion = m["http_version"].(string)
 			var respType = m["resp_type"].(string)
 			var reqType = m["req_type"].(string)
@@ -385,13 +385,13 @@ func getPropFromStepsInterface(r interface{}) (t []*models.WebCheckStep) {
 			var fullpageLoad = m["fullpage_load"].(bool)
 			var requireAuth = m["require_auth"].(bool)
 			var path = m["path"].(string)
-            var auth *models.Authentication
-            if requireAuth {
-                auth = GetAuth(m["auth"].([]interface{}))
-            }
+			var auth *models.Authentication
+			if requireAuth {
+				auth = GetAuth(m["auth"].([]interface{}))
+			}
 			var httpHeaders = m["http_headers"].(string)
 			var httpBody = m["http_body"].(string)
-            var keyword = m["keyword"].(string)
+			var keyword = m["keyword"].(string)
 			var respScript = m["resp_script"].(string)
 			var label = m["label"].(string)
 			var URL = m["url"].(string)
@@ -399,38 +399,38 @@ func getPropFromStepsInterface(r interface{}) (t []*models.WebCheckStep) {
 			var reqScript = m["req_script"].(string)
 			var typee = m["type"].(string)
 			var statusCode = m["status_code"].(string)
-            
+
 			model := &models.WebCheckStep{
-				Schema:  schema,
-				MatchType: matchType,
-                Description: description,
-                HTTPVersion: httpVersion,
-                RespType: respType,
-				ReqType: reqType,
+				Schema:            schema,
+				MatchType:         matchType,
+				Description:       description,
+				HTTPVersion:       httpVersion,
+				RespType:          respType,
+				ReqType:           reqType,
 				FollowRedirection: followRedirection,
-				HTTPMethod: httpMehod,
-				Enable: enable,
-				Name: name,
-				Timeout: timeout,
-				UseDefaultRoot: &useDefaultRoot,
-				PostDataEditType: postDataEditType,
-				FullpageLoad: fullpageLoad,
-				RequireAuth: requireAuth,
-				Path: path,
-				HTTPHeaders: httpHeaders,
-				HTTPBody: httpBody, 
-				Keyword: keyword,
-                RespScript: respScript,
-				Label: label,
-				URL: URL,
-				InvertMatch: invertMatch,
-                ReqScript: reqScript,
-				Type: typee,
-				StatusCode: statusCode,
-               }
-			   if requireAuth {
-                model.Auth = auth
-            }
+				HTTPMethod:        httpMehod,
+				Enable:            enable,
+				Name:              name,
+				Timeout:           timeout,
+				UseDefaultRoot:    &useDefaultRoot,
+				PostDataEditType:  postDataEditType,
+				FullpageLoad:      fullpageLoad,
+				RequireAuth:       requireAuth,
+				Path:              path,
+				HTTPHeaders:       httpHeaders,
+				HTTPBody:          httpBody,
+				Keyword:           keyword,
+				RespScript:        respScript,
+				Label:             label,
+				URL:               URL,
+				InvertMatch:       invertMatch,
+				ReqScript:         reqScript,
+				Type:              typee,
+				StatusCode:        statusCode,
+			}
+			if requireAuth {
+				model.Auth = auth
+			}
 			t = append(t, model)
 		}
 	}
@@ -443,11 +443,11 @@ func GetAuth(d []interface{}) (t *models.Authentication) {
 			var password = m["password"].(string)
 			var typee = m["type"].(string)
 			var domain = m["domain"].(string)
-            model := &models.Authentication{
+			model := &models.Authentication{
 				Password: &password,
 				UserName: &userName,
-				Type: &typee,
-				Domain: domain,
+				Type:     &typee,
+				Domain:   domain,
 			}
 			t = model
 		}
@@ -457,9 +457,9 @@ func GetAuth(d []interface{}) (t *models.Authentication) {
 func GetCollectorAttribute(d []interface{}) (t models.CollectorAttribute) {
 	for _, i := range d {
 		if m, ok := i.(map[string]interface{}); ok {
-           var name = m["name"].(string)
-           model := models.CollectorAttribute{
-              Name: &name,
+			var name = m["name"].(string)
+			model := models.CollectorAttribute{
+				Name: &name,
 			}
 			t = model
 		}
@@ -472,45 +472,45 @@ func GetPropFromDatapoint(d *schema.ResourceData, key string) (t []*models.DataP
 	}
 	return
 }
-func getPropFromDPInterface(r interface{}) (t []*models.DataPoint ) {
+func getPropFromDPInterface(r interface{}) (t []*models.DataPoint) {
 	for _, i := range r.([]interface{}) {
 		if m, ok := i.(map[string]interface{}); ok {
-		   var name = m["name"].(string)
-		   var postProcessorMethod = m["post_processor_method"].(string)
-		   var alertForNoData = int32(m["alert_for_no_data"].(int))
-           var postProcessorParam = m["post_processor_param"].(string)
-		   var maxDigits = int32(m["max_digits"].(int))
-		   var description = m["description"].(string)
-		   var alertClearTransitionInterval = int32(m["alert_clear_transition_interval"].(int))
-		   var alertTransitionInterval = int32(m["alert_transition_interval"].(int))
-		   var dataType = int32(m["data_type"].(int))
-		   var maxValue = m["max_value"].(string)
-		   var minValue = m["min_value"].(string)
-		   var alertBody = m["alert_body"].(string)
-		   var alertSubject = m["alert_subject"].(string)
-		   var alertExpr = m["alert_expr"].(string)
-		   var alertExprNote = m["alert_expr_note"].(string)
-		   var typee = int32(m["type"].(int))
-		   var rawDataFieldName = m["raw_data_field_name"].(string)
-         model := &models.DataPoint{
-				Name: &name,
-				Description: description,
-				AlertForNoData: alertForNoData,
-				PostProcessorParam: postProcessorParam,
-				PostProcessorMethod: postProcessorMethod,
-				MaxDigits: maxDigits,
+			var name = m["name"].(string)
+			var postProcessorMethod = m["post_processor_method"].(string)
+			var alertForNoData = int32(m["alert_for_no_data"].(int))
+			var postProcessorParam = m["post_processor_param"].(string)
+			var maxDigits = int32(m["max_digits"].(int))
+			var description = m["description"].(string)
+			var alertClearTransitionInterval = int32(m["alert_clear_transition_interval"].(int))
+			var alertTransitionInterval = int32(m["alert_transition_interval"].(int))
+			var dataType = int32(m["data_type"].(int))
+			var maxValue = m["max_value"].(string)
+			var minValue = m["min_value"].(string)
+			var alertBody = m["alert_body"].(string)
+			var alertSubject = m["alert_subject"].(string)
+			var alertExpr = m["alert_expr"].(string)
+			var alertExprNote = m["alert_expr_note"].(string)
+			var typee = int32(m["type"].(int))
+			var rawDataFieldName = m["raw_data_field_name"].(string)
+			model := &models.DataPoint{
+				Name:                         &name,
+				Description:                  description,
+				AlertForNoData:               alertForNoData,
+				PostProcessorParam:           postProcessorParam,
+				PostProcessorMethod:          postProcessorMethod,
+				MaxDigits:                    maxDigits,
 				AlertClearTransitionInterval: alertClearTransitionInterval,
-				AlertTransitionInterval: alertTransitionInterval,
-				DataType: dataType,
-				MaxValue: maxValue,
-                MinValue: minValue,
-				AlertBody: alertBody,
-				AlertSubject: alertSubject,
-				AlertExpr: alertExpr,
-				AlertExprNote: alertExprNote,
-				Type: typee,
-				RawDataFieldName: rawDataFieldName,
-             }
+				AlertTransitionInterval:      alertTransitionInterval,
+				DataType:                     dataType,
+				MaxValue:                     maxValue,
+				MinValue:                     minValue,
+				AlertBody:                    alertBody,
+				AlertSubject:                 alertSubject,
+				AlertExpr:                    alertExpr,
+				AlertExprNote:                alertExprNote,
+				Type:                         typee,
+				RawDataFieldName:             rawDataFieldName,
+			}
 			t = append(t, model)
 		}
 	}
@@ -523,20 +523,20 @@ func GetPropFromLocationMap(d *schema.ResourceData, key string) (t *models.Websi
 	return
 }
 func getPropFromLocInterface(r interface{}) (t *models.WebsiteLocation) {
-    for _, i := range r.([]interface{}) {
-    if m, ok := i.(map[string]interface{}); ok {
-        var smgIds = ConvertSetToInt32Slice(m["smg_ids"])
-		var collectorIds = ConvertSetToInt32Slice(m["collector_ids"])
-		var all = m["all"].(bool)
-          model := &models.WebsiteLocation{
-                CollectorIds: collectorIds,
-                SmgIds: smgIds,
-				All: all,
-				}
-            t = model
-        }
-    }
- return 
+	for _, i := range r.([]interface{}) {
+		if m, ok := i.(map[string]interface{}); ok {
+			var smgIds = ConvertSetToInt32Slice(m["smg_ids"])
+			var collectorIds = ConvertSetToInt32Slice(m["collector_ids"])
+			var all = m["all"].(bool)
+			model := &models.WebsiteLocation{
+				CollectorIds: collectorIds,
+				SmgIds:       smgIds,
+				All:          all,
+			}
+			t = model
+		}
+	}
+	return
 }
 func GetFilters(d []interface{}) []*models.AutoDiscoveryFilter {
 	var filters []*models.AutoDiscoveryFilter
@@ -558,4 +558,3 @@ func GetFilters(d []interface{}) []*models.AutoDiscoveryFilter {
 	}
 	return filters
 }
-

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -85,15 +85,15 @@ type AlertRule struct {
 
 	// Whether or not send anomaly suppressed alert
 	// Example: true
-	SendAnomalySuppressedAlert bool `json:"sendAnomalySuppressedAlert,omitempty"`
+	SendAnomalySuppressedAlert bool `json:"sendAnomalySuppressedAlert"`
 
 	// Whether or not status notifications for acknowledgements and SDTs should be sent to the alert rule
 	// Example: true
-	SuppressAlertAckSdt bool `json:"suppressAlertAckSdt,omitempty"`
+	SuppressAlertAckSdt bool `json:"suppressAlertAckSdt"`
 
 	// Whether or not alert clear notifications should be sent to the alert rule
 	// Example: true
-	SuppressAlertClear bool `json:"suppressAlertClear,omitempty"`
+	SuppressAlertClear bool `json:"suppressAlertClear"`
 }
 
 // Validate validates this alert rule

--- a/models/auto_discovery_configuration.go
+++ b/models/auto_discovery_configuration.go
@@ -25,10 +25,10 @@ type AutoDiscoveryConfiguration struct {
 	DataSourceName string `json:"dataSourceName,omitempty"`
 
 	// delete inactive instance
-	DeleteInactiveInstance bool `json:"deleteInactiveInstance,omitempty"`
+	DeleteInactiveInstance bool `json:"deleteInactiveInstance"`
 
 	// disable instance
-	DisableInstance bool `json:"disableInstance,omitempty"`
+	DisableInstance bool `json:"disableInstance"`
 
 	// filters
 	Filters []*AutoDiscoveryFilter `json:"filters"`
@@ -44,7 +44,7 @@ type AutoDiscoveryConfiguration struct {
 	Method *AutoDiscoveryMethod `json:"method"`
 
 	// persistent instance
-	PersistentInstance bool `json:"persistentInstance,omitempty"`
+	PersistentInstance bool `json:"persistentInstance"`
 
 	// schedule interval
 	ScheduleInterval int32 `json:"scheduleInterval,omitempty"`

--- a/models/cloud_collector_config.go
+++ b/models/cloud_collector_config.go
@@ -35,7 +35,7 @@ type CloudCollectorConfig struct {
 	Priority *int32 `json:"priority"`
 
 	// Use cloud device public ip or not
-	UsePublicIP bool `json:"usePublicIP,omitempty"`
+	UsePublicIP bool `json:"usePublicIP"`
 }
 
 // Validate validates this cloud collector config

--- a/models/cloud_normal_collector_config.go
+++ b/models/cloud_normal_collector_config.go
@@ -25,7 +25,7 @@ type CloudNormalCollectorConfig struct {
 
 	// If the normal collector config is enabled
 	// Required: true
-	Enabled *bool `json:"enabled"`
+	Enable *bool `json:"enable"`
 }
 
 // Validate validates this cloud normal collector config
@@ -74,7 +74,7 @@ func (m *CloudNormalCollectorConfig) validateCollectors(formats strfmt.Registry)
 
 func (m *CloudNormalCollectorConfig) validateEnabled(formats strfmt.Registry) error {
 
-	if err := validate.Required("enabled", "body", m.Enabled); err != nil {
+	if err := validate.Required("enable", "body", m.Enable); err != nil {
 		return err
 	}
 

--- a/models/cloud_service_settings.go
+++ b/models/cloud_service_settings.go
@@ -39,6 +39,9 @@ type CloudServiceSettings struct {
 	// If alerting should be disabled when a cloud device is terminated
 	DisableTerminatedHostAlerting bool `json:"disableTerminatedHostAlerting,omitempty"`
 
+	// Whether enhanced monitoring is enabled for this service
+	IsEnhancedMonitoringEnabled bool `json:"isEnhancedMonitoringEnabled,omitempty"`
+
 	// The regions this group will monitor
 	// Unique: true
 	MonitoringRegionInfos []string `json:"monitoringRegionInfos"`

--- a/models/cloud_service_settings.go
+++ b/models/cloud_service_settings.go
@@ -34,13 +34,13 @@ type CloudServiceSettings struct {
 	DeviceDisplayNameTemplate string `json:"deviceDisplayNameTemplate,omitempty"`
 
 	// If monitoring of stopped/terminated hosts is disabled
-	DisableStopTerminateHostMonitor bool `json:"disableStopTerminateHostMonitor,omitempty"`
+	DisableStopTerminateHostMonitor bool `json:"disableStopTerminateHostMonitor"`
 
 	// If alerting should be disabled when a cloud device is terminated
-	DisableTerminatedHostAlerting bool `json:"disableTerminatedHostAlerting,omitempty"`
+	DisableTerminatedHostAlerting bool `json:"disableTerminatedHostAlerting"`
 
 	// Whether enhanced monitoring is enabled for this service
-	IsEnhancedMonitoringEnabled bool `json:"isEnhancedMonitoringEnabled,omitempty"`
+	IsEnhancedMonitoringEnabled bool `json:"isEnhancedMonitoringEnabled"`
 
 	// The regions this group will monitor
 	// Unique: true
@@ -57,7 +57,7 @@ type CloudServiceSettings struct {
 	NormalCollectorConfig *CloudNormalCollectorConfig `json:"normalCollectorConfig,omitempty"`
 
 	// Whether or not to use all regions (can be used instead of monitoringRegions and monitoringRegionInfos)
-	SelectAll bool `json:"selectAll,omitempty"`
+	SelectAll bool `json:"selectAll"`
 
 	// Tags used to filter whether or not a cloud device is included in this group
 	Tags []*CloudTagFilter `json:"tags,omitempty"`

--- a/models/cloud_services.go
+++ b/models/cloud_services.go
@@ -18,313 +18,560 @@ import (
 // swagger:model CloudServices
 type CloudServices struct {
 
-	// APIGATEWAY monitoring settings
+	// ACM monitoring settings (AWS)
+	ACM *CloudServiceSettings `json:"ACM,omitempty"`
+
+	// AKSMANAGEDCLUSTER monitoring settings (Azure)
+	AKSMANAGEDCLUSTER *CloudServiceSettings `json:"AKSMANAGEDCLUSTER,omitempty"`
+
+	// ALARMS monitoring settings (AWS)
+	ALARMS *CloudServiceSettings `json:"ALARMS,omitempty"`
+
+	// ANALYSISSERVICE monitoring settings (Azure)
+	ANALYSISSERVICE *CloudServiceSettings `json:"ANALYSISSERVICE,omitempty"`
+
+	// APIGATEWAY monitoring settings (AWS)
 	APIGATEWAY *CloudServiceSettings `json:"APIGATEWAY,omitempty"`
 
-	// API Management
+	// APIGATEWAYV2 monitoring settings (AWS)
+	APIGATEWAYV2 *CloudServiceSettings `json:"APIGATEWAYV2,omitempty"`
+
+	// APIMANAGEMENT monitoring settings (Azure)
 	APIMANAGEMENT *CloudServiceSettings `json:"APIMANAGEMENT,omitempty"`
 
-	// APPLICATIONELB monitoring settings
+	// APPLICATIONELB monitoring settings (AWS)
 	APPLICATIONELB *CloudServiceSettings `json:"APPLICATIONELB,omitempty"`
 
-	// Application Gateway
+	// APPLICATIONGATEWAY monitoring settings (Azure)
 	APPLICATIONGATEWAY *CloudServiceSettings `json:"APPLICATIONGATEWAY,omitempty"`
 
-	// Application insights
+	// APPLICATIONINSIGHTS monitoring settings (Azure)
 	APPLICATIONINSIGHTS *CloudServiceSettings `json:"APPLICATIONINSIGHTS,omitempty"`
 
-	// App Service
+	// APPLICATIONMIGRATIONSERVICE monitoring settings (AWS)
+	APPLICATIONMIGRATIONSERVICE *CloudServiceSettings `json:"APPLICATIONMIGRATIONSERVICE,omitempty"`
+
+	// APPSERVICE monitoring settings (Azure)
 	APPSERVICE *CloudServiceSettings `json:"APPSERVICE,omitempty"`
 
-	// App Service plan
+	// APPSERVICEPLAN monitoring settings (Azure)
 	APPSERVICEPLAN *CloudServiceSettings `json:"APPSERVICEPLAN,omitempty"`
 
-	// APPSTREAM monitoring settings
+	// APPSERVICEENVIRONMENT monitoring settings (Azure)
+	APPSERVICEENVIRONMENT *CloudServiceSettings `json:"APPSERVICEENVIRONMENT,omitempty"`
+
+	// APPSTREAM monitoring settings (AWS)
 	APPSTREAM *CloudServiceSettings `json:"APPSTREAM,omitempty"`
 
-	// ATHENA monitoring settings
+	// ATHENA monitoring settings (AWS)
 	ATHENA *CloudServiceSettings `json:"ATHENA,omitempty"`
 
-	// Automation Account
+	// AUTOMATIONACCOUNT monitoring settings (Azure)
 	AUTOMATIONACCOUNT *CloudServiceSettings `json:"AUTOMATIONACCOUNT,omitempty"`
 
-	// AUTOSCALING monitoring settings
+	// AUTOSCALING monitoring settings (AWS)
 	AUTOSCALING *CloudServiceSettings `json:"AUTOSCALING,omitempty"`
 
-	// Backup protected items
+	// BACKUP monitoring settings (AWS)
+	BACKUP *CloudServiceSettings `json:"BACKUP,omitempty"`
+
+	// BACKUPPROTECTEDITEMS monitoring settings (Azure)
 	BACKUPPROTECTEDITEMS *CloudServiceSettings `json:"BACKUPPROTECTEDITEMS,omitempty"`
 
-	// Blob storage
+	// BACKUPPROTECTEDRESOURCE monitoring settings (AWS)
+	BACKUPPROTECTEDRESOURCE *CloudServiceSettings `json:"BACKUPPROTECTEDRESOURCE,omitempty"`
+
+	// BACKUPVAULT monitoring settings (Azure)
+	BACKUPVAULT *CloudServiceSettings `json:"BACKUPVAULT,omitempty"`
+
+	// BATCH monitoring settings (AWS)
+	BATCH *CloudServiceSettings `json:"BATCH,omitempty"`
+
+	// BATCHACCOUNT monitoring settings (Azure)
+	BATCHACCOUNT *CloudServiceSettings `json:"BATCHACCOUNT,omitempty"`
+
+	// BEDROCK monitoring settings (AWS)
+	BEDROCK *CloudServiceSettings `json:"BEDROCK,omitempty"`
+
+	// BLOBSTORAGE monitoring settings (Azure)
 	BLOBSTORAGE *CloudServiceSettings `json:"BLOBSTORAGE,omitempty"`
 
-	// CLOUDFRONT monitoring settings
+	// BOTSERVICES monitoring settings (Azure)
+	BOTSERVICES *CloudServiceSettings `json:"BOTSERVICES,omitempty"`
+
+	// CDNPROFILE monitoring settings (Azure)
+	CDNPROFILE *CloudServiceSettings `json:"CDNPROFILE,omitempty"`
+
+	// CLIENTVPN monitoring settings (AWS)
+	CLIENTVPN *CloudServiceSettings `json:"CLIENTVPN,omitempty"`
+
+	// CLOUDFRONT monitoring settings (AWS)
 	CLOUDFRONT *CloudServiceSettings `json:"CLOUDFRONT,omitempty"`
 
-	// CLOUDSEARCH monitoring settings
+	// CLOUDSEARCH monitoring settings (AWS)
 	CLOUDSEARCH *CloudServiceSettings `json:"CLOUDSEARCH,omitempty"`
 
-	// CODEBUILD monitoring settings
+	// CLOUDTRAIL monitoring settings (AWS)
+	CLOUDTRAIL *CloudServiceSettings `json:"CLOUDTRAIL,omitempty"`
+
+	// CLOUDWATCHEVENTS monitoring settings (AWS)
+	CLOUDWATCHEVENTS *CloudServiceSettings `json:"CLOUDWATCHEVENTS,omitempty"`
+
+	// CLOUDWATCHLOGS monitoring settings (AWS)
+	CLOUDWATCHLOGS *CloudServiceSettings `json:"CLOUDWATCHLOGS,omitempty"`
+
+	// CLOUDWATCHSYNTHETICS monitoring settings (AWS)
+	CLOUDWATCHSYNTHETICS *CloudServiceSettings `json:"CLOUDWATCHSYNTHETICS,omitempty"`
+
+	// CODEBUILD monitoring settings (AWS)
 	CODEBUILD *CloudServiceSettings `json:"CODEBUILD,omitempty"`
 
-	// CognitiveSearch
+	// COGNITIVESEARCH monitoring settings (Azure)
 	COGNITIVESEARCH *CloudServiceSettings `json:"COGNITIVESEARCH,omitempty"`
 
-	// Cognitive Services
+	// COGNITIVESERVICES monitoring settings (Azure)
 	COGNITIVESERVICES *CloudServiceSettings `json:"COGNITIVESERVICES,omitempty"`
 
-	// COGNITO monitoring settings
+	// COGNITO monitoring settings (AWS)
 	COGNITO *CloudServiceSettings `json:"COGNITO,omitempty"`
 
-	// CosmosDB
+	// CONTAINERAPPS monitoring settings (Azure)
+	CONTAINERAPPS *CloudServiceSettings `json:"CONTAINERAPPS,omitempty"`
+
+	// CONTAINERINSTANCE monitoring settings (Azure)
+	CONTAINERINSTANCE *CloudServiceSettings `json:"CONTAINERINSTANCE,omitempty"`
+
+	// CONTAINERREGISTRY monitoring settings (Azure)
+	CONTAINERREGISTRY *CloudServiceSettings `json:"CONTAINERREGISTRY,omitempty"`
+
+	// COSMOSDB monitoring settings (Azure)
 	COSMOSDB *CloudServiceSettings `json:"COSMOSDB,omitempty"`
 
-	// Data Factory
+	// DATAFACTORY monitoring settings (Azure)
 	DATAFACTORY *CloudServiceSettings `json:"DATAFACTORY,omitempty"`
 
-	// DIRECTCONNECT monitoring settings
+	// DATALAKEANALYTICS monitoring settings (Azure)
+	DATALAKEANALYTICS *CloudServiceSettings `json:"DATALAKEANALYTICS,omitempty"`
+
+	// DBCLUSTER monitoring settings (AWS)
+	DBCLUSTER *CloudServiceSettings `json:"DBCLUSTER,omitempty"`
+
+	// DATALAKESTORE monitoring settings (Azure)
+	DATALAKESTORE *CloudServiceSettings `json:"DATALAKESTORE,omitempty"`
+
+	// DATABRICKS monitoring settings (Azure)
+	DATABRICKS *CloudServiceSettings `json:"DATABRICKS,omitempty"`
+
+	// DETECTIVEGRAPH monitoring settings (AWS)
+	DETECTIVEGRAPH *CloudServiceSettings `json:"DETECTIVEGRAPH,omitempty"`
+
+	// DIRECTCONNECT monitoring settings (AWS)
 	DIRECTCONNECT *CloudServiceSettings `json:"DIRECTCONNECT,omitempty"`
 
-	// DMSREPLICATION monitoring settings
+	// DIRECTCONNECTVIRTUALINTERFACE monitoring settings (AWS)
+	DIRECTCONNECTVIRTUALINTERFACE *CloudServiceSettings `json:"DIRECTCONNECTVIRTUALINTERFACE,omitempty"`
+
+	// DISKS monitoring settings (Azure)
+	DISKS *CloudServiceSettings `json:"DISKS,omitempty"`
+
+	// DMSREPLICATION monitoring settings (AWS)
 	DMSREPLICATION *CloudServiceSettings `json:"DMSREPLICATION,omitempty"`
 
-	// DMSREPLICATIONTASKS monitoring settings
+	// DMSREPLICATIONTASKS monitoring settings (AWS)
 	DMSREPLICATIONTASKS *CloudServiceSettings `json:"DMSREPLICATIONTASKS,omitempty"`
 
-	// DOCDB monitoring settings
+	// DOCDB monitoring settings (AWS)
 	DOCDB *CloudServiceSettings `json:"DOCDB,omitempty"`
 
-	// DYNAMODB monitoring settings
+	// DYNAMODB monitoring settings (AWS)
 	DYNAMODB *CloudServiceSettings `json:"DYNAMODB,omitempty"`
 
-	// EBS monitoring settings
+	// EBS monitoring settings (AWS)
 	EBS *CloudServiceSettings `json:"EBS,omitempty"`
 
-	// EC2 monitoring settings
+	// EC2 monitoring settings (AWS)
 	EC2 *CloudServiceSettings `json:"EC2,omitempty"`
 
-	// ECS monitoring settings
+	// ECR monitoring settings (AWS)
+	ECR *CloudServiceSettings `json:"ECR,omitempty"`
+
+	// ECS monitoring settings (AWS)
 	ECS *CloudServiceSettings `json:"ECS,omitempty"`
 
-	// EFS monitoring settings
+	// EFS monitoring settings (AWS)
 	EFS *CloudServiceSettings `json:"EFS,omitempty"`
 
-	// ELASTICACHE monitoring settings
+	// EKS monitoring settings (AWS)
+	EKS *CloudServiceSettings `json:"EKS,omitempty"`
+
+	// ELASTICACHE monitoring settings (AWS)
 	ELASTICACHE *CloudServiceSettings `json:"ELASTICACHE,omitempty"`
 
-	// ELASTICBEANSTALK monitoring settings
+	// ELASTICBEANSTALK monitoring settings (AWS)
 	ELASTICBEANSTALK *CloudServiceSettings `json:"ELASTICBEANSTALK,omitempty"`
 
-	// ELASTICSEARCH monitoring settings
+	// ELASTICIP monitoring settings (AWS)
+	ELASTICIP *CloudServiceSettings `json:"ELASTICIP,omitempty"`
+
+	// ELASTICSEARCH monitoring settings (AWS)
 	ELASTICSEARCH *CloudServiceSettings `json:"ELASTICSEARCH,omitempty"`
 
-	// ELASTICTRANSCODER monitoring settings
+	// ELASTICTRANSCODER monitoring settings (AWS)
 	ELASTICTRANSCODER *CloudServiceSettings `json:"ELASTICTRANSCODER,omitempty"`
 
-	// ELB monitoring settings
+	// ELB monitoring settings (AWS)
 	ELB *CloudServiceSettings `json:"ELB,omitempty"`
 
-	// EMR monitoring settings
+	// EMR monitoring settings (AWS)
 	EMR *CloudServiceSettings `json:"EMR,omitempty"`
 
-	// EVENTBRIDGE monitoring settings
+	// EVENTBRIDGE monitoring settings (AWS)
 	EVENTBRIDGE *CloudServiceSettings `json:"EVENTBRIDGE,omitempty"`
 
-	// Event Hub
+	// EVENTGRID monitoring settings (Azure)
+	EVENTGRID *CloudServiceSettings `json:"EVENTGRID,omitempty"`
+
+	// EVENTHUB monitoring settings (Azure)
 	EVENTHUB *CloudServiceSettings `json:"EVENTHUB,omitempty"`
 
-	// Express Route Circuit
+	// EXPRESSROUTECIRCUIT monitoring settings (Azure)
 	EXPRESSROUTECIRCUIT *CloudServiceSettings `json:"EXPRESSROUTECIRCUIT,omitempty"`
 
-	// File storage
+	// FILESTORAGE monitoring settings (Azure)
 	FILESTORAGE *CloudServiceSettings `json:"FILESTORAGE,omitempty"`
 
-	// FIREHOSE monitoring settings
+	// FIREHOSE monitoring settings (AWS)
 	FIREHOSE *CloudServiceSettings `json:"FIREHOSE,omitempty"`
 
-	// Firewall
+	// FIREWALL monitoring settings (Azure)
 	FIREWALL *CloudServiceSettings `json:"FIREWALL,omitempty"`
 
-	// Front Doors
+	// FRONTDOORS monitoring settings (Azure)
 	FRONTDOORS *CloudServiceSettings `json:"FRONTDOORS,omitempty"`
 
-	// FSX monitoring settings
+	// FSX monitoring settings (AWS)
 	FSX *CloudServiceSettings `json:"FSX,omitempty"`
 
-	// GLUE monitoring settings
+	// FUNCTION monitoring settings (Azure)
+	FUNCTION *CloudServiceSettings `json:"FUNCTION,omitempty"`
+
+	// GATEWAYELB monitoring settings (AWS)
+	GATEWAYELB *CloudServiceSettings `json:"GATEWAYELB,omitempty"`
+
+	// GLOBALNETWORKS monitoring settings (AWS)
+	GLOBALNETWORKS *CloudServiceSettings `json:"GLOBALNETWORKS,omitempty"`
+
+	// GLUE monitoring settings (AWS)
 	GLUE *CloudServiceSettings `json:"GLUE,omitempty"`
 
-	// Key vault
+	// HEALTHCHECK monitoring settings (AWS)
+	HEALTHCHECK *CloudServiceSettings `json:"HEALTHCHECK,omitempty"`
+
+	// HDINSIGHT monitoring settings (Azure)
+	HDINSIGHT *CloudServiceSettings `json:"HDINSIGHT,omitempty"`
+
+	// HOSTEDZONE monitoring settings (AWS)
+	HOSTEDZONE *CloudServiceSettings `json:"HOSTEDZONE,omitempty"`
+
+	// IAMROLE monitoring settings (AWS)
+	IAMROLE *CloudServiceSettings `json:"IAMROLE,omitempty"`
+
+	// INTERNETGATEWAY monitoring settings (AWS)
+	INTERNETGATEWAY *CloudServiceSettings `json:"INTERNETGATEWAY,omitempty"`
+
+	// IOTHUB monitoring settings (Azure)
+	IOTHUB *CloudServiceSettings `json:"IOTHUB,omitempty"`
+
+	// KEYVAULT monitoring settings (Azure)
 	KEYVAULT *CloudServiceSettings `json:"KEYVAULT,omitempty"`
 
-	// KINESIS monitoring settings
+	// KMS monitoring settings (AWS)
+	KMS *CloudServiceSettings `json:"KMS,omitempty"`
+
+	// KINESIS monitoring settings (AWS)
 	KINESIS *CloudServiceSettings `json:"KINESIS,omitempty"`
 
-	// KINESISVIDEO monitoring settings
+	// KINESISVIDEO monitoring settings (AWS)
 	KINESISVIDEO *CloudServiceSettings `json:"KINESISVIDEO,omitempty"`
 
-	// LAMBDA monitoring settings
+	// LAMBDA monitoring settings (AWS)
 	LAMBDA *CloudServiceSettings `json:"LAMBDA,omitempty"`
 
-	// Load balancers
+	// LIGHTSAIL monitoring settings (AWS)
+	LIGHTSAIL *CloudServiceSettings `json:"LIGHTSAIL,omitempty"`
+
+	// LOADBALANCERS monitoring settings (Azure)
 	LOADBALANCERS *CloudServiceSettings `json:"LOADBALANCERS,omitempty"`
 
-	// Log Analytics Workspaces
+	// LOGANALYTICSWORKSPACES monitoring settings (Azure)
 	LOGANALYTICSWORKSPACES *CloudServiceSettings `json:"LOGANALYTICSWORKSPACES,omitempty"`
 
-	// Logic Apps
+	// LOGICAPPS monitoring settings (Azure)
 	LOGICAPPS *CloudServiceSettings `json:"LOGICAPPS,omitempty"`
 
-	// MEDIACONNECT monitoring settings
+	// MEDIACONNECT monitoring settings (AWS)
 	MEDIACONNECT *CloudServiceSettings `json:"MEDIACONNECT,omitempty"`
 
-	// MEDIACONVERT monitoring settings
+	// MEDIACONVERT monitoring settings (AWS)
 	MEDIACONVERT *CloudServiceSettings `json:"MEDIACONVERT,omitempty"`
 
-	// MEDIAPACKAGELIVE monitoring settings
+	// MEDIAPACKAGELIVE monitoring settings (AWS)
 	MEDIAPACKAGELIVE *CloudServiceSettings `json:"MEDIAPACKAGELIVE,omitempty"`
 
-	// MEDIAPACKAGEVOD monitoring settings
+	// MEDIAPACKAGEVOD monitoring settings (AWS)
 	MEDIAPACKAGEVOD *CloudServiceSettings `json:"MEDIAPACKAGEVOD,omitempty"`
 
-	// MEDIASTORE monitoring settings
+	// MEDIASTORE monitoring settings (AWS)
 	MEDIASTORE *CloudServiceSettings `json:"MEDIASTORE,omitempty"`
 
-	// MEDIATAILOR monitoring settings
+	// MEDIATAILOR monitoring settings (AWS)
 	MEDIATAILOR *CloudServiceSettings `json:"MEDIATAILOR,omitempty"`
 
-	// MQ monitoring settings
+	// MLWORKSPACES monitoring settings (Azure)
+	MLWORKSPACES *CloudServiceSettings `json:"MLWORKSPACES,omitempty"`
+
+	// MQ monitoring settings (AWS)
 	MQ *CloudServiceSettings `json:"MQ,omitempty"`
 
-	// MSKBROKER monitoring settings
+	// MARIADB monitoring settings (Azure)
+	MARIADB *CloudServiceSettings `json:"MARIADB,omitempty"`
+
+	// MSKBROKER monitoring settings (AWS)
 	MSKBROKER *CloudServiceSettings `json:"MSKBROKER,omitempty"`
 
-	// MSKCLUSTER monitoring settings
+	// MSKCLUSTER monitoring settings (AWS)
 	MSKCLUSTER *CloudServiceSettings `json:"MSKCLUSTER,omitempty"`
 
-	// My sql
+	// MYSQL monitoring settings (Azure)
 	MYSQL *CloudServiceSettings `json:"MYSQL,omitempty"`
 
-	// NATGATEWAY monitoring settings
+	// MYSQLFLEXIBLE monitoring settings (Azure)
+	MYSQLFLEXIBLE *CloudServiceSettings `json:"MYSQLFLEXIBLE,omitempty"`
+
+	// NATGATEWAY monitoring settings (AWS)
 	NATGATEWAY *CloudServiceSettings `json:"NATGATEWAY,omitempty"`
 
-	// NETWORKELB monitoring settings
+	// NATGATEWAYS monitoring settings (Azure)
+	NATGATEWAYS *CloudServiceSettings `json:"NATGATEWAYS,omitempty"`
+
+	// NETAPPPOOLS monitoring settings (Azure)
+	NETAPPPOOLS *CloudServiceSettings `json:"NETAPPPOOLS,omitempty"`
+
+	// NETWORKELB monitoring settings (AWS)
 	NETWORKELB *CloudServiceSettings `json:"NETWORKELB,omitempty"`
 
-	// Network interface
+	// NETWORKFIREWALL monitoring settings (AWS)
+	NETWORKFIREWALL *CloudServiceSettings `json:"NETWORKFIREWALL,omitempty"`
+
+	// NETWORKINTERFACE monitoring settings (Azure)
 	NETWORKINTERFACE *CloudServiceSettings `json:"NETWORKINTERFACE,omitempty"`
 
-	// OPSWORKS monitoring settings
+	// NLBTARGETGROUP monitoring settings (AWS)
+	NLBTARGETGROUP *CloudServiceSettings `json:"NLBTARGETGROUP,omitempty"`
+
+	// NOTIFICATIONHUBS monitoring settings (Azure)
+	NOTIFICATIONHUBS *CloudServiceSettings `json:"NOTIFICATIONHUBS,omitempty"`
+
+	// OPENAISERVICES monitoring settings (Azure)
+	OPENAISERVICES *CloudServiceSettings `json:"OPENAISERVICES,omitempty"`
+
+	// OPSWORKS monitoring settings (AWS)
 	OPSWORKS *CloudServiceSettings `json:"OPSWORKS,omitempty"`
 
-	// PostgreSQL
+	// POSTGRESQL monitoring settings (Azure)
 	POSTGRESQL *CloudServiceSettings `json:"POSTGRESQL,omitempty"`
 
-	// Public IP
+	// POSTGRESQLCITUS monitoring settings (Azure)
+	POSTGRESQLCITUS *CloudServiceSettings `json:"POSTGRESQLCITUS,omitempty"`
+
+	// POSTGRESQLFLEXIBLE monitoring settings (Azure)
+	POSTGRESQLFLEXIBLE *CloudServiceSettings `json:"POSTGRESQLFLEXIBLE,omitempty"`
+
+	// POWERBIEMBEDDED monitoring settings (Azure)
+	POWERBIEMBEDDED *CloudServiceSettings `json:"POWERBIEMBEDDED,omitempty"`
+
+	// PRIVATELINKENDPOINTS monitoring settings (AWS)
+	PRIVATELINKENDPOINTS *CloudServiceSettings `json:"PRIVATELINKENDPOINTS,omitempty"`
+
+	// PRIVATELINKSERVICES monitoring settings (AWS)
+	PRIVATELINKSERVICES *CloudServiceSettings `json:"PRIVATELINKSERVICES,omitempty"`
+
+	// PUBLICIP monitoring settings (Azure)
 	PUBLICIP *CloudServiceSettings `json:"PUBLICIP,omitempty"`
 
-	// Queue storage
+	// QBUSINESS monitoring settings (AWS)
+	QBUSINESS *CloudServiceSettings `json:"QBUSINESS,omitempty"`
+
+	// QUICKSIGHTDASHBOARDS monitoring settings (AWS)
+	QUICKSIGHTDASHBOARDS *CloudServiceSettings `json:"QUICKSIGHTDASHBOARDS,omitempty"`
+
+	// QUICKSIGHTDATASETS monitoring settings (AWS)
+	QUICKSIGHTDATASETS *CloudServiceSettings `json:"QUICKSIGHTDATASETS,omitempty"`
+
+	// QUOTA monitoring settings (AWS)
+	QUOTA *CloudServiceSettings `json:"QUOTA,omitempty"`
+
+	// QUEUESTORAGE monitoring settings (Azure)
 	QUEUESTORAGE *CloudServiceSettings `json:"QUEUESTORAGE,omitempty"`
 
-	// RDS monitoring settings
+	// RDS monitoring settings (AWS)
 	RDS *CloudServiceSettings `json:"RDS,omitempty"`
 
-	// Recovery Protected Item
+	// RECOVERYPROTECTEDITEM monitoring settings (Azure)
 	RECOVERYPROTECTEDITEM *CloudServiceSettings `json:"RECOVERYPROTECTEDITEM,omitempty"`
 
-	// Recovery Services
+	// RECOVERYPROTECTEDITEMS monitoring settings (Azure)
+	RECOVERYPROTECTEDITEMS *CloudServiceSettings `json:"RECOVERYPROTECTEDITEMS,omitempty"`
+
+	// RECOVERYSERVICES monitoring settings (Azure)
 	RECOVERYSERVICES *CloudServiceSettings `json:"RECOVERYSERVICES,omitempty"`
 
-	// Redis Cache
+	// REDISCACHE monitoring settings (Azure)
 	REDISCACHE *CloudServiceSettings `json:"REDISCACHE,omitempty"`
 
-	// REDSHIFT monitoring settings
+	// REDISCACHEENTERPRISE monitoring settings (Azure)
+	REDISCACHEENTERPRISE *CloudServiceSettings `json:"REDISCACHEENTERPRISE,omitempty"`
+
+	// REDSHIFT monitoring settings (AWS)
 	REDSHIFT *CloudServiceSettings `json:"REDSHIFT,omitempty"`
 
-	// ROUTE53 monitoring settings
+	// REDSHIFTSERVERLESS monitoring settings (AWS)
+	REDSHIFTSERVERLESS *CloudServiceSettings `json:"REDSHIFTSERVERLESS,omitempty"`
+
+	// RELAYNAMESPACES monitoring settings (Azure)
+	RELAYNAMESPACES *CloudServiceSettings `json:"RELAYNAMESPACES,omitempty"`
+
+	// ROUTE53 monitoring settings (AWS)
 	ROUTE53 *CloudServiceSettings `json:"ROUTE53,omitempty"`
 
-	// ROUTE53RESOLVER monitoring settings
+	// ROUTE53HOSTEDZONE monitoring settings (AWS)
+	ROUTE53HOSTEDZONE *CloudServiceSettings `json:"ROUTE53HOSTEDZONE,omitempty"`
+
+	// ROUTE53RESOLVER monitoring settings (AWS)
 	ROUTE53RESOLVER *CloudServiceSettings `json:"ROUTE53RESOLVER,omitempty"`
 
-	// S3 monitoring settings
+	// S3 monitoring settings (AWS)
 	S3 *CloudServiceSettings `json:"S3,omitempty"`
 
-	// SAGEMAKER monitoring settings
+	// SAGEMAKER monitoring settings (AWS)
 	SAGEMAKER *CloudServiceSettings `json:"SAGEMAKER,omitempty"`
 
-	// Service Bus
+	// SERVICEBUS monitoring settings (Azure)
 	SERVICEBUS *CloudServiceSettings `json:"SERVICEBUS,omitempty"`
 
-	// SES monitoring settings
+	// SERVICEFABRICMESH monitoring settings (Azure)
+	SERVICEFABRICMESH *CloudServiceSettings `json:"SERVICEFABRICMESH,omitempty"`
+
+	// SES monitoring settings (AWS)
 	SES *CloudServiceSettings `json:"SES,omitempty"`
 
-	// SNS monitoring settings
+	// SIGNALR monitoring settings (Azure)
+	SIGNALR *CloudServiceSettings `json:"SIGNALR,omitempty"`
+
+	// SITE2SITEVPN monitoring settings (AWS)
+	SITE2SITEVPN *CloudServiceSettings `json:"SITE2SITEVPN,omitempty"`
+
+	// SNS monitoring settings (AWS)
 	SNS *CloudServiceSettings `json:"SNS,omitempty"`
 
-	// SQL database
+	// SQLDATABASE monitoring settings (Azure)
 	SQLDATABASE *CloudServiceSettings `json:"SQLDATABASE,omitempty"`
 
-	// SQL ElasticPool
+	// SQLELASTICPOOL monitoring settings (Azure)
 	SQLELASTICPOOL *CloudServiceSettings `json:"SQLELASTICPOOL,omitempty"`
 
-	// SQL Managed Instance
+	// SQLMANAGEDINSTANCE monitoring settings (Azure)
 	SQLMANAGEDINSTANCE *CloudServiceSettings `json:"SQLMANAGEDINSTANCE,omitempty"`
 
-	// SQS monitoring settings
+	// SQS monitoring settings (AWS)
 	SQS *CloudServiceSettings `json:"SQS,omitempty"`
 
-	// STEPFUNCTIONS monitoring settings
+	// STEPFUNCTIONS monitoring settings (AWS)
 	STEPFUNCTIONS *CloudServiceSettings `json:"STEPFUNCTIONS,omitempty"`
 
-	// Storage account
+	// STORAGEACCOUNT monitoring settings (Azure)
 	STORAGEACCOUNT *CloudServiceSettings `json:"STORAGEACCOUNT,omitempty"`
 
-	// SWFACTIVITY monitoring settings
+	// STORAGEGATEWAY monitoring settings (AWS)
+	STORAGEGATEWAY *CloudServiceSettings `json:"STORAGEGATEWAY,omitempty"`
+
+	// STREAMANALYTICS monitoring settings (Azure)
+	STREAMANALYTICS *CloudServiceSettings `json:"STREAMANALYTICS,omitempty"`
+
+	// SWFACTIVITY monitoring settings (AWS)
 	SWFACTIVITY *CloudServiceSettings `json:"SWFACTIVITY,omitempty"`
 
-	// SWFWORKFLOW monitoring settings
+	// SWFWORKFLOW monitoring settings (AWS)
 	SWFWORKFLOW *CloudServiceSettings `json:"SWFWORKFLOW,omitempty"`
 
-	// SynapseWorkSpaces
+	// SYNAPSEWORKSPACES monitoring settings (Azure)
 	SYNAPSEWORKSPACES *CloudServiceSettings `json:"SYNAPSEWORKSPACES,omitempty"`
 
-	// Table storage
+	// TABLESTORAGE monitoring settings (Azure)
 	TABLESTORAGE *CloudServiceSettings `json:"TABLESTORAGE,omitempty"`
 
-	// TRAFFICMANAGER
+	// TRAFFICMANAGER monitoring settings (Azure)
 	TRAFFICMANAGER *CloudServiceSettings `json:"TRAFFICMANAGER,omitempty"`
 
-	// TRANSITGATEWAY monitoring settings
+	// TRANSFER monitoring settings (AWS)
+	TRANSFER *CloudServiceSettings `json:"TRANSFER,omitempty"`
+
+	// TRANSITGATEWAY monitoring settings (AWS)
 	TRANSITGATEWAY *CloudServiceSettings `json:"TRANSITGATEWAY,omitempty"`
 
-	// Virtual Desktop
+	// TRANSITGATEWAYATTACHMENT monitoring settings (AWS)
+	TRANSITGATEWAYATTACHMENT *CloudServiceSettings `json:"TRANSITGATEWAYATTACHMENT,omitempty"`
+
+	// VIRTUALDESKTOP monitoring settings (Azure)
 	VIRTUALDESKTOP *CloudServiceSettings `json:"VIRTUALDESKTOP,omitempty"`
 
-	// VIRTUAL machine
+	// VIRTUALHUBS monitoring settings (Azure)
+	VIRTUALHUBS *CloudServiceSettings `json:"VIRTUALHUBS,omitempty"`
+
+	// VIRTUALMACHINE monitoring settings (Azure)
 	VIRTUALMACHINE *CloudServiceSettings `json:"VIRTUALMACHINE,omitempty"`
 
-	// Virtual Machine Scale Set
+	// VIRTUALMACHINESCALESET monitoring settings (Azure)
 	VIRTUALMACHINESCALESET *CloudServiceSettings `json:"VIRTUALMACHINESCALESET,omitempty"`
 
-	// Virtual machine scale set VM
+	// VIRTUALMACHINESCALESETVM monitoring settings (Azure)
 	VIRTUALMACHINESCALESETVM *CloudServiceSettings `json:"VIRTUALMACHINESCALESETVM,omitempty"`
 
-	// Virtual Network Gateway
+	// VIRTUALNETWORKGATEWAY monitoring settings (Azure)
 	VIRTUALNETWORKGATEWAY *CloudServiceSettings `json:"VIRTUALNETWORKGATEWAY,omitempty"`
 
-	// VPN monitoring settings
+	// VIRTUALNETWORKS monitoring settings (Azure)
+	VIRTUALNETWORKS *CloudServiceSettings `json:"VIRTUALNETWORKS,omitempty"`
+
+	// VPC monitoring settings (AWS)
+	VPC *CloudServiceSettings `json:"VPC,omitempty"`
+
+	// VPCENDPOINT monitoring settings (AWS)
+	VPCENDPOINT *CloudServiceSettings `json:"VPCENDPOINT,omitempty"`
+
+	// VPCPEERING monitoring settings (AWS)
+	VPCPEERING *CloudServiceSettings `json:"VPCPEERING,omitempty"`
+
+	// VPN monitoring settings (Azure)
 	VPN *CloudServiceSettings `json:"VPN,omitempty"`
 
-	// WORKSPACE monitoring settings
+	// VPNGATEWAYS monitoring settings (Azure)
+	VPNGATEWAYS *CloudServiceSettings `json:"VPNGATEWAYS,omitempty"`
+
+	// WORKSPACE monitoring settings (AWS)
 	WORKSPACE *CloudServiceSettings `json:"WORKSPACE,omitempty"`
 
-	// WORKSPACEDIRECTORY monitoring settings
+	// WORKSPACEDIRECTORY monitoring settings (AWS)
 	WORKSPACEDIRECTORY *CloudServiceSettings `json:"WORKSPACEDIRECTORY,omitempty"`
 }
 
 // Validate validates this cloud services
 func (m *CloudServices) Validate(formats strfmt.Registry) error {
 	var res []error
+
+	if err := m.validateACM(formats); err != nil {
+		res = append(res, err)
+	}
 
 	if err := m.validateAPIGATEWAY(formats); err != nil {
 		res = append(res, err)
@@ -343,6 +590,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateAPPLICATIONINSIGHTS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateAPPLICATIONMIGRATIONSERVICE(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -370,7 +621,19 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateBACKUP(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateBACKUPPROTECTEDITEMS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateBACKUPPROTECTEDRESOURCE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateBEDROCK(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -410,7 +673,15 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateDBCLUSTER(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateDIRECTCONNECT(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDIRECTCONNECTVIRTUALINTERFACE(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -442,7 +713,15 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateECR(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateEFS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateEKS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -499,6 +778,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateFSX(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateGATEWAYELB(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -598,7 +881,27 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validatePRIVATELINKENDPOINTS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePRIVATELINKSERVICES(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateQBUSINESS(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateQUEUESTORAGE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateQUICKSIGHTDASHBOARDS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateQUICKSIGHTDATASETS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -607,6 +910,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRECOVERYPROTECTEDITEM(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRECOVERYPROTECTEDITEMS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -622,7 +929,15 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateREDSHIFTSERVERLESS(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateROUTE53(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateROUTE53HOSTEDZONE(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -1298,6 +1613,25 @@ func (m *CloudServices) validateEFS(formats strfmt.Registry) error {
 				return ve.ValidateName("EFS")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("EFS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateEKS(formats strfmt.Registry) error {
+	if swag.IsZero(m.EKS) { // not required
+		return nil
+	}
+
+	if m.EKS != nil {
+		if err := m.EKS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("EKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("EKS")
 			}
 			return err
 		}
@@ -2085,6 +2419,25 @@ func (m *CloudServices) validateRECOVERYPROTECTEDITEM(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *CloudServices) validateRECOVERYPROTECTEDITEMS(formats strfmt.Registry) error {
+	if swag.IsZero(m.RECOVERYPROTECTEDITEMS) { // not required
+		return nil
+	}
+
+	if m.RECOVERYPROTECTEDITEMS != nil {
+		if err := m.RECOVERYPROTECTEDITEMS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("RECOVERYPROTECTEDITEMS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("RECOVERYPROTECTEDITEMS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateRECOVERYSERVICES(formats strfmt.Registry) error {
 	if swag.IsZero(m.RECOVERYSERVICES) { // not required
 		return nil
@@ -2655,9 +3008,317 @@ func (m *CloudServices) validateWORKSPACEDIRECTORY(formats strfmt.Registry) erro
 	return nil
 }
 
+func (m *CloudServices) validateACM(formats strfmt.Registry) error {
+	if swag.IsZero(m.ACM) { // not required
+		return nil
+	}
+
+	if m.ACM != nil {
+		if err := m.ACM.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ACM")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ACM")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateAPPLICATIONMIGRATIONSERVICE(formats strfmt.Registry) error {
+	if swag.IsZero(m.APPLICATIONMIGRATIONSERVICE) { // not required
+		return nil
+	}
+
+	if m.APPLICATIONMIGRATIONSERVICE != nil {
+		if err := m.APPLICATIONMIGRATIONSERVICE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateBACKUP(formats strfmt.Registry) error {
+	if swag.IsZero(m.BACKUP) { // not required
+		return nil
+	}
+
+	if m.BACKUP != nil {
+		if err := m.BACKUP.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUP")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateBACKUPPROTECTEDRESOURCE(formats strfmt.Registry) error {
+	if swag.IsZero(m.BACKUPPROTECTEDRESOURCE) { // not required
+		return nil
+	}
+
+	if m.BACKUPPROTECTEDRESOURCE != nil {
+		if err := m.BACKUPPROTECTEDRESOURCE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUPPROTECTEDRESOURCE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUPPROTECTEDRESOURCE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateBEDROCK(formats strfmt.Registry) error {
+	if swag.IsZero(m.BEDROCK) { // not required
+		return nil
+	}
+
+	if m.BEDROCK != nil {
+		if err := m.BEDROCK.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BEDROCK")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BEDROCK")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDBCLUSTER(formats strfmt.Registry) error {
+	if swag.IsZero(m.DBCLUSTER) { // not required
+		return nil
+	}
+
+	if m.DBCLUSTER != nil {
+		if err := m.DBCLUSTER.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DBCLUSTER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DBCLUSTER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDIRECTCONNECTVIRTUALINTERFACE(formats strfmt.Registry) error {
+	if swag.IsZero(m.DIRECTCONNECTVIRTUALINTERFACE) { // not required
+		return nil
+	}
+
+	if m.DIRECTCONNECTVIRTUALINTERFACE != nil {
+		if err := m.DIRECTCONNECTVIRTUALINTERFACE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateECR(formats strfmt.Registry) error {
+	if swag.IsZero(m.ECR) { // not required
+		return nil
+	}
+
+	if m.ECR != nil {
+		if err := m.ECR.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ECR")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ECR")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateGATEWAYELB(formats strfmt.Registry) error {
+	if swag.IsZero(m.GATEWAYELB) { // not required
+		return nil
+	}
+
+	if m.GATEWAYELB != nil {
+		if err := m.GATEWAYELB.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("GATEWAYELB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("GATEWAYELB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validatePRIVATELINKENDPOINTS(formats strfmt.Registry) error {
+	if swag.IsZero(m.PRIVATELINKENDPOINTS) { // not required
+		return nil
+	}
+
+	if m.PRIVATELINKENDPOINTS != nil {
+		if err := m.PRIVATELINKENDPOINTS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKENDPOINTS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKENDPOINTS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validatePRIVATELINKSERVICES(formats strfmt.Registry) error {
+	if swag.IsZero(m.PRIVATELINKSERVICES) { // not required
+		return nil
+	}
+
+	if m.PRIVATELINKSERVICES != nil {
+		if err := m.PRIVATELINKSERVICES.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKSERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKSERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateQBUSINESS(formats strfmt.Registry) error {
+	if swag.IsZero(m.QBUSINESS) { // not required
+		return nil
+	}
+
+	if m.QBUSINESS != nil {
+		if err := m.QBUSINESS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QBUSINESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QBUSINESS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateQUICKSIGHTDASHBOARDS(formats strfmt.Registry) error {
+	if swag.IsZero(m.QUICKSIGHTDASHBOARDS) { // not required
+		return nil
+	}
+
+	if m.QUICKSIGHTDASHBOARDS != nil {
+		if err := m.QUICKSIGHTDASHBOARDS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDASHBOARDS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDASHBOARDS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateQUICKSIGHTDATASETS(formats strfmt.Registry) error {
+	if swag.IsZero(m.QUICKSIGHTDATASETS) { // not required
+		return nil
+	}
+
+	if m.QUICKSIGHTDATASETS != nil {
+		if err := m.QUICKSIGHTDATASETS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDATASETS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDATASETS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateREDSHIFTSERVERLESS(formats strfmt.Registry) error {
+	if swag.IsZero(m.REDSHIFTSERVERLESS) { // not required
+		return nil
+	}
+
+	if m.REDSHIFTSERVERLESS != nil {
+		if err := m.REDSHIFTSERVERLESS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("REDSHIFTSERVERLESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("REDSHIFTSERVERLESS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateROUTE53HOSTEDZONE(formats strfmt.Registry) error {
+	if swag.IsZero(m.ROUTE53HOSTEDZONE) { // not required
+		return nil
+	}
+
+	if m.ROUTE53HOSTEDZONE != nil {
+		if err := m.ROUTE53HOSTEDZONE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ROUTE53HOSTEDZONE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ROUTE53HOSTEDZONE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this cloud services based on the context it is used
 func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
+
+	if err := m.contextValidateACM(ctx, formats); err != nil {
+		res = append(res, err)
+	}
 
 	if err := m.contextValidateAPIGATEWAY(ctx, formats); err != nil {
 		res = append(res, err)
@@ -2676,6 +3337,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 	}
 
 	if err := m.contextValidateAPPLICATIONINSIGHTS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateAPPLICATIONMIGRATIONSERVICE(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2703,7 +3368,19 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateBACKUP(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateBACKUPPROTECTEDITEMS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateBACKUPPROTECTEDRESOURCE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateBEDROCK(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2743,7 +3420,15 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateDBCLUSTER(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateDIRECTCONNECT(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDIRECTCONNECTVIRTUALINTERFACE(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2775,7 +3460,15 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateECR(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateEFS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateEKS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2832,6 +3525,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 	}
 
 	if err := m.contextValidateFSX(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGATEWAYELB(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2931,7 +3628,27 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidatePRIVATELINKENDPOINTS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePRIVATELINKSERVICES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateQBUSINESS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateQUEUESTORAGE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateQUICKSIGHTDASHBOARDS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateQUICKSIGHTDATASETS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2940,6 +3657,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 	}
 
 	if err := m.contextValidateRECOVERYPROTECTEDITEM(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRECOVERYPROTECTEDITEMS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2955,7 +3676,15 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateREDSHIFTSERVERLESS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateROUTE53(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateROUTE53HOSTEDZONE(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -3541,6 +4270,22 @@ func (m *CloudServices) contextValidateEFS(ctx context.Context, formats strfmt.R
 				return ve.ValidateName("EFS")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("EFS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateEKS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.EKS != nil {
+		if err := m.EKS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("EKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("EKS")
 			}
 			return err
 		}
@@ -4205,6 +4950,22 @@ func (m *CloudServices) contextValidateRECOVERYPROTECTEDITEM(ctx context.Context
 	return nil
 }
 
+func (m *CloudServices) contextValidateRECOVERYPROTECTEDITEMS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.RECOVERYPROTECTEDITEMS != nil {
+		if err := m.RECOVERYPROTECTEDITEMS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("RECOVERYPROTECTEDITEMS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("RECOVERYPROTECTEDITEMS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateRECOVERYSERVICES(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.RECOVERYSERVICES != nil {
@@ -4677,6 +5438,262 @@ func (m *CloudServices) contextValidateWORKSPACEDIRECTORY(ctx context.Context, f
 				return ve.ValidateName("WORKSPACEDIRECTORY")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("WORKSPACEDIRECTORY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateACM(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ACM != nil {
+		if err := m.ACM.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ACM")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ACM")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateAPPLICATIONMIGRATIONSERVICE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.APPLICATIONMIGRATIONSERVICE != nil {
+		if err := m.APPLICATIONMIGRATIONSERVICE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateBACKUP(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BACKUP != nil {
+		if err := m.BACKUP.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUP")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateBACKUPPROTECTEDRESOURCE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BACKUPPROTECTEDRESOURCE != nil {
+		if err := m.BACKUPPROTECTEDRESOURCE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUPPROTECTEDRESOURCE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUPPROTECTEDRESOURCE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateBEDROCK(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BEDROCK != nil {
+		if err := m.BEDROCK.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BEDROCK")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BEDROCK")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDBCLUSTER(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DBCLUSTER != nil {
+		if err := m.DBCLUSTER.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DBCLUSTER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DBCLUSTER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDIRECTCONNECTVIRTUALINTERFACE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DIRECTCONNECTVIRTUALINTERFACE != nil {
+		if err := m.DIRECTCONNECTVIRTUALINTERFACE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateECR(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ECR != nil {
+		if err := m.ECR.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ECR")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ECR")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateGATEWAYELB(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.GATEWAYELB != nil {
+		if err := m.GATEWAYELB.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("GATEWAYELB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("GATEWAYELB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidatePRIVATELINKENDPOINTS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PRIVATELINKENDPOINTS != nil {
+		if err := m.PRIVATELINKENDPOINTS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKENDPOINTS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKENDPOINTS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidatePRIVATELINKSERVICES(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PRIVATELINKSERVICES != nil {
+		if err := m.PRIVATELINKSERVICES.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKSERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKSERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateQBUSINESS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.QBUSINESS != nil {
+		if err := m.QBUSINESS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QBUSINESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QBUSINESS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateQUICKSIGHTDASHBOARDS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.QUICKSIGHTDASHBOARDS != nil {
+		if err := m.QUICKSIGHTDASHBOARDS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDASHBOARDS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDASHBOARDS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateQUICKSIGHTDATASETS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.QUICKSIGHTDATASETS != nil {
+		if err := m.QUICKSIGHTDATASETS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDATASETS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDATASETS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateREDSHIFTSERVERLESS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.REDSHIFTSERVERLESS != nil {
+		if err := m.REDSHIFTSERVERLESS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("REDSHIFTSERVERLESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("REDSHIFTSERVERLESS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateROUTE53HOSTEDZONE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ROUTE53HOSTEDZONE != nil {
+		if err := m.ROUTE53HOSTEDZONE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ROUTE53HOSTEDZONE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ROUTE53HOSTEDZONE")
 			}
 			return err
 		}

--- a/models/collector.go
+++ b/models/collector.go
@@ -58,7 +58,7 @@ type Collector struct {
 
 	// Whether the collector can be downgraded to a lower version
 	// Read Only: true
-	CanDowngrade *bool `json:"canDowngrade,omitempty"`
+	CanDowngrade *bool `json:"canDowngrade"`
 
 	// The reason why the collector can be downgraded
 	// Read Only: true
@@ -66,7 +66,7 @@ type Collector struct {
 
 	// Whether or not an alert clear notifcation has been sent for this Collector
 	// Read Only: true
-	ClearSent *bool `json:"clearSent,omitempty"`
+	ClearSent *bool `json:"clearSent"`
 
 	// The Collector's configuration file
 	// Read Only: true
@@ -113,15 +113,15 @@ type Collector struct {
 
 	// Whether the collector is in EA version
 	// Example: false
-	Ea *bool `json:"ea,omitempty"`
+	Ea *bool `json:"ea"`
 
 	// Whether or not automatic failback is enabled for the Collector, the default value is true
 	// Example: true
-	EnableFailBack bool `json:"enableFailBack,omitempty"`
+	EnableFailBack bool `json:"enableFailBack"`
 
 	// Whether or not the device the Collector is installed on is enabled for fail over
 	// Example: true
-	EnableFailOverOnCollectorDevice bool `json:"enableFailOverOnCollectorDevice,omitempty"`
+	EnableFailOverOnCollectorDevice bool `json:"enableFailOverOnCollectorDevice"`
 
 	// The Id of the escalation chain associated with this Collector
 	// Example: 80
@@ -129,7 +129,7 @@ type Collector struct {
 
 	// Whether the collector has failover devices
 	// Read Only: true
-	HasFailOverDevice *bool `json:"hasFailOverDevice,omitempty"`
+	HasFailOverDevice *bool `json:"hasFailOverDevice"`
 
 	// The hostname of the device the Collector is installed on
 	// Read Only: true
@@ -141,7 +141,7 @@ type Collector struct {
 
 	// The SDT status of the collector
 	// Read Only: true
-	InSDT *bool `json:"inSDT,omitempty"`
+	InSDT *bool `json:"inSDT"`
 
 	// A map of the collector urls and (if linux) commands to download the collector installer
 	// Read Only: true
@@ -149,7 +149,7 @@ type Collector struct {
 
 	// Whether or not the Collector is currently down
 	// Read Only: true
-	IsDown *bool `json:"isDown,omitempty"`
+	IsDown *bool `json:"isDown"`
 
 	// The time, in epoch format, that a notification was last sent for the Collector
 	// Read Only: true
@@ -161,11 +161,11 @@ type Collector struct {
 
 	// Check if we shall monitor using local account (for windows)
 	// Example: false
-	MonitorOthers *bool `json:"monitorOthers,omitempty"`
+	MonitorOthers *bool `json:"monitorOthers"`
 
 	// Whether to create a collector device when instance collector, the default value is true
 	// Example: true
-	NeedAutoCreateCollectorDevice bool `json:"needAutoCreateCollectorDevice,omitempty"`
+	NeedAutoCreateCollectorDevice bool `json:"needAutoCreateCollectorDevice"`
 
 	// The Netscan version associated with the Collector
 	// Read Only: true
@@ -227,7 +227,7 @@ type Collector struct {
 
 	// Whether alert clear notifications are suppressed for the Collector
 	// Example: true
-	SuppressAlertClear bool `json:"suppressAlertClear,omitempty"`
+	SuppressAlertClear bool `json:"suppressAlertClear"`
 
 	// The time the Collector has been up, in seconds
 	// Read Only: true

--- a/models/collector_base.go
+++ b/models/collector_base.go
@@ -26,7 +26,7 @@ type CollectorBase struct {
 
 	// Whether or not the Collector is currently acknowledged
 	// Read Only: true
-	Acked *bool `json:"acked,omitempty"`
+	Acked *bool `json:"acked"`
 
 	// The user that acknowledged the Collector (if it is in alert)
 	// Read Only: true
@@ -57,7 +57,7 @@ type CollectorBase struct {
 
 	// Whether the collector can be downgraded to a lower version
 	// Read Only: true
-	CanDowngrade *bool `json:"canDowngrade,omitempty"`
+	CanDowngrade *bool `json:"canDowngrade"`
 
 	// The reason why the collector can be downgraded
 	// Read Only: true
@@ -65,7 +65,7 @@ type CollectorBase struct {
 
 	// Whether or not an alert clear notifcation has been sent for this Collector
 	// Read Only: true
-	ClearSent *bool `json:"clearSent,omitempty"`
+	ClearSent *bool `json:"clearSent"`
 
 	// The Collector's configuration file
 	// Read Only: true
@@ -108,15 +108,15 @@ type CollectorBase struct {
 
 	// Whether the collector is in EA version
 	// Read Only: true
-	Ea *bool `json:"ea,omitempty"`
+	Ea *bool `json:"ea"`
 
 	// Whether or not automatic failback is enabled for the Collector, the default value is true
 	// Example: true
-	EnableFailBack bool `json:"enableFailBack,omitempty"`
+	EnableFailBack bool `json:"enableFailBack"`
 
 	// Whether or not the device the Collector is installed on is enabled for fail over
 	// Example: true
-	EnableFailOverOnCollectorDevice bool `json:"enableFailOverOnCollectorDevice,omitempty"`
+	EnableFailOverOnCollectorDevice bool `json:"enableFailOverOnCollectorDevice"`
 
 	// The Id of the escalation chain associated with this Collector
 	// Example: 80
@@ -124,7 +124,7 @@ type CollectorBase struct {
 
 	// Whether the collector has failover devices
 	// Read Only: true
-	HasFailOverDevice *bool `json:"hasFailOverDevice,omitempty"`
+	HasFailOverDevice *bool `json:"hasFailOverDevice"`
 
 	// The hostname of the device the Collector is installed on
 	// Read Only: true
@@ -136,11 +136,11 @@ type CollectorBase struct {
 
 	// The SDT status of the collector
 	// Read Only: true
-	InSDT *bool `json:"inSDT,omitempty"`
+	InSDT *bool `json:"inSDT"`
 
 	// Whether or not the Collector is currently down
 	// Read Only: true
-	IsDown *bool `json:"isDown,omitempty"`
+	IsDown *bool `json:"isDown"`
 
 	// The time, in epoch format, that a notification was last sent for the Collector
 	// Read Only: true
@@ -152,7 +152,7 @@ type CollectorBase struct {
 
 	// Whether to create a collector device when instance collector, the default value is true
 	// Example: true
-	NeedAutoCreateCollectorDevice bool `json:"needAutoCreateCollectorDevice,omitempty"`
+	NeedAutoCreateCollectorDevice bool `json:"needAutoCreateCollectorDevice"`
 
 	// The Netscan version associated with the Collector
 	// Read Only: true
@@ -209,7 +209,7 @@ type CollectorBase struct {
 
 	// Whether alert clear notifications are suppressed for the Collector
 	// Example: true
-	SuppressAlertClear bool `json:"suppressAlertClear,omitempty"`
+	SuppressAlertClear bool `json:"suppressAlertClear"`
 
 	// The time the Collector has been up, in seconds
 	// Read Only: true

--- a/models/collector_group.go
+++ b/models/collector_group.go
@@ -23,7 +23,7 @@ type CollectorGroup struct {
 
 	// Denotes whether or not the collector group should be auto balanced
 	// Example: true
-	AutoBalance bool `json:"autoBalance,omitempty"`
+	AutoBalance bool `json:"autoBalance"`
 
 	// Threshold for instance count strategy to check if a collector has high load
 	// Example: 10000

--- a/models/collector_version.go
+++ b/models/collector_version.go
@@ -21,11 +21,11 @@ type CollectorVersion struct {
 
 	// True if Linux collector available
 	// Read Only: true
-	Has32bitLinux *bool `json:"has32bitLinux,omitempty"`
+	Has32bitLinux *bool `json:"has32bitLinux"`
 
 	// True if Windows collector available
 	// Read Only: true
-	Has32bitWindows *bool `json:"has32bitWindows,omitempty"`
+	Has32bitWindows *bool `json:"has32bitWindows"`
 
 	// The collector major version
 	// Read Only: true
@@ -33,7 +33,7 @@ type CollectorVersion struct {
 
 	// True if collector is a required release
 	// Read Only: true
-	Mandatory *bool `json:"mandatory,omitempty"`
+	Mandatory *bool `json:"mandatory"`
 
 	// The collector minor version
 	// Read Only: true
@@ -45,7 +45,7 @@ type CollectorVersion struct {
 
 	// False for early release. True for general release
 	// Read Only: true
-	Stable *bool `json:"stable,omitempty"`
+	Stable *bool `json:"stable"`
 }
 
 // Validate validates this collector version

--- a/models/dashboard.go
+++ b/models/dashboard.go
@@ -55,7 +55,7 @@ type Dashboard struct {
 
 	// Whether or not the dashboard is sharable. This value will always be true unless the dashboard is a private dashboard
 	// Example: true
-	Sharable bool `json:"sharable,omitempty"`
+	Sharable bool `json:"sharable"`
 
 	// The template which is used for import dashboard
 	Template interface{} `json:"template,omitempty"`

--- a/models/dashboard_data.go
+++ b/models/dashboard_data.go
@@ -29,7 +29,7 @@ type DashboardData struct {
 
 	// sharable
 	// Read Only: true
-	Sharable *bool `json:"sharable,omitempty"`
+	Sharable *bool `json:"sharable"`
 
 	// user permission
 	// Read Only: true

--- a/models/datasource.go
+++ b/models/datasource.go
@@ -72,11 +72,11 @@ type Datasource struct {
 
 	// Enable Auto Discovery or not when this data source has multi instance: false|true
 	// Example: false
-	EnableAutoDiscovery bool `json:"enableAutoDiscovery,omitempty"`
+	EnableAutoDiscovery bool `json:"enableAutoDiscovery"`
 
 	// Enable ERI Discovery or not: false|true
 	// Example: false
-	EnableEriDiscovery bool `json:"enableEriDiscovery,omitempty"`
+	EnableEriDiscovery bool `json:"enableEriDiscovery"`
 
 	// eri discovery config
 	EriDiscoveryConfig *ScriptERIDiscoveryAttributeV2 `json:"eriDiscoveryConfig,omitempty"`
@@ -90,7 +90,7 @@ type Datasource struct {
 	Group string `json:"group,omitempty"`
 
 	// If the DataSource has multi instance: true|false
-	HasMultiInstances bool `json:"hasMultiInstances,omitempty"`
+	HasMultiInstances bool `json:"hasMultiInstances"`
 
 	// The ID of the LMModule
 	// Read Only: true
@@ -123,7 +123,7 @@ type Datasource struct {
 
 	// Use wild-value as unique identifier in case of multi instance datasource: true|false
 	// Read Only: true
-	UseWildValueAsUUID *bool `json:"useWildValueAsUUID,omitempty"`
+	UseWildValueAsUUID *bool `json:"useWildValueAsUUID"`
 
 	// The data source version
 	// Read Only: true

--- a/models/device.go
+++ b/models/device.go
@@ -50,7 +50,7 @@ type Device struct {
 	CollectorDescription string `json:"collectorDescription,omitempty"`
 
 	// request contains multi value field
-	ContainsMultiValue bool `json:"containsMultiValue,omitempty"`
+	ContainsMultiValue bool `json:"containsMultiValue"`
 
 	// The time, in epoch seconds format, that the device was added to your LogicMonitor account
 	// Read Only: true
@@ -81,7 +81,7 @@ type Device struct {
 
 	// Indicates whether alerting is disabled (true) or enabled (false) for this device
 	// Example: true
-	DisableAlerting bool `json:"disableAlerting,omitempty"`
+	DisableAlerting bool `json:"disableAlerting"`
 
 	// The display name of the device
 	// Example: Cisco Router
@@ -90,7 +90,7 @@ type Device struct {
 
 	// Indicates whether Netflow is enabled (true) or disabled (false) for the device
 	// Example: true
-	EnableNetflow bool `json:"enableNetflow,omitempty"`
+	EnableNetflow bool `json:"enableNetflow"`
 
 	// The Azure instance state (if applicable): 1 indicates that the instance is running, 2 indicates that the instance is stopped and 3 the instance is terminated.
 	// Read Only: true
@@ -114,7 +114,7 @@ type Device struct {
 
 	// Indicates whether Preferred Log Collector is configured  (true) or not (false) for the device
 	// Example: true
-	IsPreferredLogCollectorConfigured bool `json:"isPreferredLogCollectorConfigured,omitempty"`
+	IsPreferredLogCollectorConfigured bool `json:"isPreferredLogCollectorConfigured"`
 
 	// The last time, in epoch seconds, that the device received Netflow data
 	// Read Only: true
@@ -139,7 +139,7 @@ type Device struct {
 
 	// Indicates whether Static group and sorted Custom properties are needed
 	// Example: true
-	NeedStcGrpAndSortedCP *bool `json:"needStcGrpAndSortedCP,omitempty"`
+	NeedStcGrpAndSortedCP *bool `json:"needStcGrpAndSortedCP"`
 
 	// The description/name of the netflow collector for this device
 	// Read Only: true

--- a/models/device_group.go
+++ b/models/device_group.go
@@ -73,11 +73,11 @@ type DeviceGroup struct {
 
 	// Indicates whether alerting is disabled (true) or enabled (false) for this device group
 	// Example: true
-	DisableAlerting bool `json:"disableAlerting,omitempty"`
+	DisableAlerting bool `json:"disableAlerting"`
 
 	// Whether or not alerting is effectively disabled for this device group (alerting may be disabled at a higher level, e.g. parent group)
 	// Read Only: true
-	EffectiveAlertEnabled *bool `json:"effectiveAlertEnabled,omitempty"`
+	EffectiveAlertEnabled *bool `json:"effectiveAlertEnabled"`
 
 	// Indicates whether Netflow is enabled (true) or disabled (false) for the device group, the default value is true
 	// Example: true
@@ -114,7 +114,7 @@ type DeviceGroup struct {
 
 	// Whether if any Netflow enabled devices in this device group
 	// Read Only: true
-	HasNetflowEnabledDevices *bool `json:"hasNetflowEnabledDevices,omitempty"`
+	HasNetflowEnabledDevices *bool `json:"hasNetflowEnabledDevices"`
 
 	// The id of the device group
 	// Read Only: true

--- a/models/escalation_chain.go
+++ b/models/escalation_chain.go
@@ -34,7 +34,7 @@ type EscalationChain struct {
 
 	// if throttle needs to be enabled then true if not then false.
 	// Example: true
-	EnableThrottling bool `json:"enableThrottling,omitempty"`
+	EnableThrottling bool `json:"enableThrottling"`
 
 	// id
 	// Read Only: true
@@ -42,7 +42,7 @@ type EscalationChain struct {
 
 	// in alerting
 	// Read Only: true
-	InAlerting *bool `json:"inAlerting,omitempty"`
+	InAlerting *bool `json:"inAlerting"`
 
 	// the chain name
 	// Example: NOC Team

--- a/models/integration_metadata.go
+++ b/models/integration_metadata.go
@@ -30,11 +30,11 @@ type IntegrationMetadata struct {
 
 	// Specifies if the Applies To function is changed from origin or not
 	// Read Only: true
-	IsChangedFromOrigin *bool `json:"isChangedFromOrigin,omitempty"`
+	IsChangedFromOrigin *bool `json:"isChangedFromOrigin"`
 
 	// Specifies if the Applies To function is changed from target last published or not
 	// Read Only: true
-	IsChangedFromTargetLastPublished *bool `json:"isChangedFromTargetLastPublished,omitempty"`
+	IsChangedFromTargetLastPublished *bool `json:"isChangedFromTargetLastPublished"`
 
 	// The LocalModule Id
 	// Read Only: true

--- a/models/next_upgrade_info.go
+++ b/models/next_upgrade_info.go
@@ -25,7 +25,7 @@ type NextUpgradeInfo struct {
 
 	// mandatory
 	// Read Only: true
-	Mandatory *bool `json:"mandatory,omitempty"`
+	Mandatory *bool `json:"mandatory"`
 
 	// minor version
 	// Read Only: true
@@ -33,7 +33,7 @@ type NextUpgradeInfo struct {
 
 	// stable
 	// Read Only: true
-	Stable *bool `json:"stable,omitempty"`
+	Stable *bool `json:"stable"`
 
 	// upgrade time
 	// Read Only: true

--- a/models/rest_highest_priority_collector_status.go
+++ b/models/rest_highest_priority_collector_status.go
@@ -21,15 +21,15 @@ type RestHighestPriorityCollectorStatus struct {
 
 	// The acked status of the highest priority sub collector
 	// Read Only: true
-	Acked *bool `json:"acked,omitempty"`
+	Acked *bool `json:"acked"`
 
 	// The SDT status of the highest priority sub collector
 	// Read Only: true
-	InSDT *bool `json:"inSDT,omitempty"`
+	InSDT *bool `json:"inSDT"`
 
 	// The down status of the highest priority sub collector
 	// Read Only: true
-	IsDown *bool `json:"isDown,omitempty"`
+	IsDown *bool `json:"isDown"`
 
 	// The status of the highest priority sub collector
 	// Read Only: true

--- a/models/sdt.go
+++ b/models/sdt.go
@@ -115,7 +115,7 @@ type Sdt struct {
 	// The values can be true|false, where true: the SDT is currently active
 	// false: the SDT is currently inactive
 	// Read Only: true
-	IsEffective *bool `json:"isEffective,omitempty"`
+	IsEffective *bool `json:"isEffective"`
 
 	// The values can be 1 | 2....| 60. Specifies the minute of the hour that the SDT should begin for a repeating SDT
 	// Example: 6

--- a/models/web_check.go
+++ b/models/web_check.go
@@ -32,7 +32,7 @@ type WebCheck struct {
 
 	// Whether or not SSL should be ignored, the default value is true
 	// Example: true
-	IgnoreSSL bool `json:"ignoreSSL,omitempty"`
+	IgnoreSSL bool `json:"ignoreSSL"`
 
 	// The time in milliseconds that the page must load within for each step to avoid triggering an alert
 	// Example: 30000
@@ -47,11 +47,11 @@ type WebCheck struct {
 
 	// Whether or not SSL expiration alerts should be triggered
 	// Example: false
-	TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert,omitempty"`
+	TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert"`
 
 	// Whether or not SSL status alerts should be triggered
 	// Example: false
-	TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert,omitempty"`
+	TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert"`
 }
 
 // UnmarshalJSON unmarshals this object from a JSON structure
@@ -69,7 +69,7 @@ func (m *WebCheck) UnmarshalJSON(raw []byte) error {
 
 		Domain *string `json:"domain"`
 
-		IgnoreSSL bool `json:"ignoreSSL,omitempty"`
+		IgnoreSSL bool `json:"ignoreSSL"`
 
 		PageLoadAlertTimeInMS int64 `json:"pageLoadAlertTimeInMS,omitempty"`
 
@@ -77,9 +77,9 @@ func (m *WebCheck) UnmarshalJSON(raw []byte) error {
 
 		Steps []*WebCheckStep `json:"steps"`
 
-		TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert,omitempty"`
+		TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert"`
 
-		TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert,omitempty"`
+		TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert"`
 	}
 	if err := swag.ReadJSON(raw, &dataAO1); err != nil {
 		return err
@@ -118,7 +118,7 @@ func (m WebCheck) MarshalJSON() ([]byte, error) {
 
 		Domain *string `json:"domain"`
 
-		IgnoreSSL bool `json:"ignoreSSL,omitempty"`
+		IgnoreSSL bool `json:"ignoreSSL"`
 
 		PageLoadAlertTimeInMS int64 `json:"pageLoadAlertTimeInMS,omitempty"`
 
@@ -126,9 +126,9 @@ func (m WebCheck) MarshalJSON() ([]byte, error) {
 
 		Steps []*WebCheckStep `json:"steps"`
 
-		TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert,omitempty"`
+		TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert"`
 
-		TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert,omitempty"`
+		TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert"`
 	}
 
 	dataAO1.AlertExpr = m.AlertExpr

--- a/models/web_check_step.go
+++ b/models/web_check_step.go
@@ -43,22 +43,22 @@ type WebCheckStep struct {
 
 	// true | false
 	// Specifies whether to enable step or not
-	Enable bool `json:"enable,omitempty"`
+	Enable bool `json:"enable"`
 
 	// true | false
 	// Specifies whether to follow redirection or not
 	// Example: true
-	FollowRedirection bool `json:"followRedirection,omitempty"`
+	FollowRedirection bool `json:"followRedirection"`
 
 	// true | false
 	// Checks if full page should be loaded or not
 	// Example: false
-	FullpageLoad bool `json:"fullpageLoad,omitempty"`
+	FullpageLoad bool `json:"fullpageLoad"`
 
 	// true | false
 	// Checks if invert matches or not
 	// Example: false
-	InvertMatch bool `json:"invertMatch,omitempty"`
+	InvertMatch bool `json:"invertMatch"`
 
 	// Keyword that matches the body
 	Keyword string `json:"keyword,omitempty"`
@@ -91,7 +91,7 @@ type WebCheckStep struct {
 	// true | false
 	// Checks if authorization required or not
 	// Example: false
-	RequireAuth bool `json:"requireAuth,omitempty"`
+	RequireAuth bool `json:"requireAuth"`
 
 	// The Step Response Script
 	RespScript string `json:"respScript,omitempty"`

--- a/models/website.go
+++ b/models/website.go
@@ -32,7 +32,7 @@ type Website struct {
 	// true: alerting is disabled for the website
 	// false: alerting is enabled for the website
 	// If stopMonitoring=true, then alerting will also by default be disabled for the website
-	DisableAlerting bool `json:"disableAlerting,omitempty"`
+	DisableAlerting bool `json:"disableAlerting"`
 
 	// Required for type=webcheck , The domain of the service. This is the base URL of the service
 	// Example: www.ebay.com
@@ -60,7 +60,7 @@ type Website struct {
 
 	// Whether or not SSL should be ignored, the default value is true
 	// Example: true
-	IgnoreSSL bool `json:"ignoreSSL,omitempty"`
+	IgnoreSSL bool `json:"ignoreSSL"`
 
 	// warn | error | critical
 	// The level of alert to trigger if the website fails a check from an individual test location
@@ -70,11 +70,11 @@ type Website struct {
 	// true: an alert will be triggered if a check fails from an individual test location
 	// false: an alert will not be triggered if a check fails from an individual test location
 	// Example: false
-	IndividualSmAlertEnable bool `json:"individualSmAlertEnable,omitempty"`
+	IndividualSmAlertEnable bool `json:"individualSmAlertEnable"`
 
 	// Whether or not the website is internal
 	// Example: false
-	IsInternal bool `json:"isInternal,omitempty"`
+	IsInternal bool `json:"isInternal"`
 
 	// The time (in epoch format) that the website was updated
 	// Read Only: true
@@ -109,12 +109,12 @@ type Website struct {
 	// true: monitoring is disabled for the website
 	// false: monitoring is enabled for the website
 	// If stopMonitoring=true, then alerting will also by default be disabled for the website
-	StopMonitoring bool `json:"stopMonitoring,omitempty"`
+	StopMonitoring bool `json:"stopMonitoring"`
 
 	// true: monitoring is disabled for all services in the website's folder
 	// false: monitoring is not disabled for all services in website's folder
 	// Read Only: true
-	StopMonitoringByFolder *bool `json:"stopMonitoringByFolder,omitempty"`
+	StopMonitoringByFolder *bool `json:"stopMonitoringByFolder"`
 
 	// The website template
 	Template interface{} `json:"template,omitempty"`
@@ -135,11 +135,11 @@ type Website struct {
 
 	// Whether or not SSL expiration alerts should be triggered
 	// Example: false
-	TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert,omitempty"`
+	TriggerSSLExpirationAlert bool `json:"triggerSSLExpirationAlert"`
 
 	// Whether or not SSL status alerts should be triggered
 	// Example: false
-	TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert,omitempty"`
+	TriggerSSLStatusAlert bool `json:"triggerSSLStatusAlert"`
 
 	// The type of the website. Acceptable values are: pingcheck, webcheck
 	// Example: webcheck
@@ -149,12 +149,12 @@ type Website struct {
 	// true: The alert settings configured in the website Default Settings will be used
 	// false: Service Default Settings will not be used, and you will need to specify individualSMAlertEnable, individualAlertLevel, globalSmAlertConf, overallAlertLevel and pollingInterval
 	// Example: true
-	UseDefaultAlertSetting bool `json:"useDefaultAlertSetting,omitempty"`
+	UseDefaultAlertSetting bool `json:"useDefaultAlertSetting"`
 
 	// true: The checkpoint locations configured in the website Default Settings will be used
 	// false: The checkpoint locations specified in the testLocation will be used
 	// Example: false
-	UseDefaultLocationSetting bool `json:"useDefaultLocationSetting,omitempty"`
+	UseDefaultLocationSetting bool `json:"useDefaultLocationSetting"`
 
 	// write | read | ack. The permission level of the user that made the API request
 	UserPermission string `json:"userPermission,omitempty"`

--- a/models/website_group.go
+++ b/models/website_group.go
@@ -29,7 +29,7 @@ type WebsiteGroup struct {
 	// false: alerting is enabled for the websites in the group
 	// If stopMonitoring=true, then alerting will also by default be disabled for the websites in the group
 	// Example: false
-	DisableAlerting bool `json:"disableAlerting,omitempty"`
+	DisableAlerting bool `json:"disableAlerting"`
 
 	// The full path of the group
 	// Read Only: true
@@ -37,7 +37,7 @@ type WebsiteGroup struct {
 
 	// has websites disabled
 	// Read Only: true
-	HasWebsitesDisabled *bool `json:"hasWebsitesDisabled,omitempty"`
+	HasWebsitesDisabled *bool `json:"hasWebsitesDisabled"`
 
 	// The Id of the group
 	// Read Only: true
@@ -71,7 +71,7 @@ type WebsiteGroup struct {
 	// false: monitoring is enabled for the websites in the group
 	// If stopMonitoring=true, then alerting will also by default be disabled for the websites in the group
 	// Example: false
-	StopMonitoring bool `json:"stopMonitoring,omitempty"`
+	StopMonitoring bool `json:"stopMonitoring"`
 
 	// An object that indicates the websites locations.
 	// eg. {'all': false, smgId:[1,2,3], collectorIds:[14,16]}

--- a/models/website_location.go
+++ b/models/website_location.go
@@ -21,7 +21,7 @@ type WebsiteLocation struct {
 
 	// all
 	// Example: true
-	All bool `json:"all,omitempty"`
+	All bool `json:"all"`
 
 	// collector ids
 	CollectorIds []int32 `json:"collectorIds"`


### PR DESCRIPTION
This PR modernizes the cloud services integration by updating a 2-year-old CloudServices model and fixes a critical bug that prevented cloud collectors from being properly enabled.

🔧 Key Fixes
1. CloudNormalCollectorConfig Bug Fix

Issue: The field was incorrectly named enabled instead of enable
Impact: This typo prevented users from properly enabling cloud collectors in Terraform configurations
Resolution: Corrected property name to enable throughout the codebase

2. CloudServices Model Update

The PR includes comprehensive updates to cloud service monitoring schemas for both AWS and Azure services. While the full list of services requires viewing all 158 changed files (the API response is limited to 30 results), this represents a major update to support current cloud AWS/Azure service offerings.

3. Code Quality Improvements

 Standard Go Formatting: All Go files have been formatted using go fmt
 Recommendation: The PR suggests using make fmt in future contributions to maintain consistent code style

🔗 Related Issues

 Fixes: [Issue #93](https://github.com/logicmonitor/terraform-provider-logicmonitor/issues/93)
 Replaces: [PR #113](https://github.com/logicmonitor/terraform-provider-logicmonitor/pull/113)