### PR TITLE
AWS and Azure Additional Services Added

### DIFF
--- a/examples/device_group/resource.tf
+++ b/examples/device_group/resource.tf
@@ -201,7 +201,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -221,7 +221,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -242,7 +242,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -263,7 +263,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -284,7 +284,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -304,7 +304,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -324,7 +324,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -344,7 +344,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -364,7 +364,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -384,7 +384,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -404,7 +404,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -424,7 +424,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -444,7 +444,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -464,7 +464,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -484,7 +484,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -504,7 +504,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -524,7 +524,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -544,7 +544,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -564,7 +564,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -584,7 +584,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -604,7 +604,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -624,7 +624,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -644,7 +644,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -664,7 +664,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -684,7 +684,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -704,7 +704,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -724,7 +724,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -744,7 +744,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -764,7 +764,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -784,7 +784,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         # disable_terminated_host_alerting = true
         # normal_collector_config {
         #   collectors = []
-        #   enabled    = false
+        #   enable    = false
         # }
         # custom_n_s_p_schedule = ""
         # select_all            = true
@@ -804,7 +804,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -824,7 +824,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true

--- a/logicmonitor/schemata/cloud_normal_collector_config_schema.go
+++ b/logicmonitor/schemata/cloud_normal_collector_config_schema.go
@@ -9,7 +9,7 @@ import (
 func CloudNormalCollectorConfigSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"collectors": {
-			Type: schema.TypeList, //GoType: []*CloudCollectorConfig 
+			Type: schema.TypeList, //GoType: []*CloudCollectorConfig  
 			Elem: &schema.Resource{
 				Schema: CloudCollectorConfigSchema(),
 			},
@@ -17,7 +17,7 @@ func CloudNormalCollectorConfigSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 		
-		"enabled": {
+		"enable": {
 			Type: schema.TypeBool,
 			Required: true,
 		},
@@ -30,7 +30,7 @@ func SetCloudNormalCollectorConfigSubResourceData(m []*models.CloudNormalCollect
 		if cloudNormalCollectorConfig != nil {
 			properties := make(map[string]interface{})
 			properties["collectors"] = SetCloudCollectorConfigSubResourceData(cloudNormalCollectorConfig.Collectors)
-			properties["enabled"] = cloudNormalCollectorConfig.Enabled
+			properties["enable"] = cloudNormalCollectorConfig.Enable
 			d = append(d, &properties)
 		}
 	}
@@ -40,17 +40,17 @@ func SetCloudNormalCollectorConfigSubResourceData(m []*models.CloudNormalCollect
 func CloudNormalCollectorConfigModel(d map[string]interface{}) *models.CloudNormalCollectorConfig {
 	// assume that the incoming map only contains the relevant resource data
 	collectors := utils.GetCloudCollectorConfigs(d["collectors"].([]interface{}))
-	enabled := d["enabled"].(bool)
+	enable := d["enable"].(bool)
 	
 	return &models.CloudNormalCollectorConfig {
 		Collectors: collectors,
-		Enabled: &enabled,
+		Enable: &enable,
 	}
 }
 
 func GetCloudNormalCollectorConfigPropertyFields() (t []string) {
 	return []string{
 		"collectors",
-		"enabled",
+		"enable",
 	}
 }

--- a/logicmonitor/schemata/cloud_services_schema.go
+++ b/logicmonitor/schemata/cloud_services_schema.go
@@ -2,12 +2,43 @@ package schemata
 
 import (
 	"terraform-provider-logicmonitor/models"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func CloudServicesSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"a_c_m": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"a_l_a_r_m_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"a_n_a_l_y_s_i_s_s_e_r_v_i_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"api_g_a_t_e_w_a_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -15,7 +46,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"api_g_a_t_e_w_a_y_v2": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"api_m_a_n_a_g_e_m_e_n_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -23,7 +62,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_p_p_l_i_c_a_t_i_o_n_e_l_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -31,7 +70,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_p_p_l_i_c_a_t_i_o_n_g_a_t_e_w_a_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -39,7 +78,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_p_p_l_i_c_a_t_i_o_n_i_n_s_i_g_h_t_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -47,7 +86,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"a_p_p_s_e_r_v_i_c_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -55,7 +102,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"a_p_p_s_e_r_v_i_c_e_p_l_a_n": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -63,7 +118,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_p_p_s_t_r_e_a_m": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -71,7 +126,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_t_h_e_n_a": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -79,7 +134,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_u_t_o_m_a_t_i_o_n_a_c_c_o_u_n_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -87,7 +142,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"a_u_t_o_s_c_a_l_i_n_g": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -95,7 +150,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"b_a_c_k_u_p": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -103,7 +166,31 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"b_a_t_c_h_a_c_c_o_u_n_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"b_e_d_r_o_c_k": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"b_l_o_b_s_t_o_r_a_g_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -111,7 +198,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"b_o_t_s_e_r_v_i_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"c_d_n_p_r_o_f_i_l_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"c_l_o_u_d_f_r_o_n_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -119,7 +222,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"c_l_o_u_d_s_e_a_r_c_h": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -127,7 +230,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"c_o_d_e_b_ui_l_d": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -135,7 +238,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"c_o_g_n_i_t_i_v_e_s_e_a_r_c_h": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -143,7 +246,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"c_o_g_n_i_t_i_v_e_s_e_r_v_i_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -151,7 +254,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"c_o_g_n_i_t_o": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -159,7 +262,31 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"c_o_n_t_a_i_n_e_r_a_p_p_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"c_o_s_m_o_s_d_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -167,7 +294,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"d_a_t_a_b_r_i_c_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"d_a_t_a_f_a_c_t_o_r_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -175,7 +310,31 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"d_a_t_a_l_a_k_e_s_t_o_r_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"d_b_c_l_u_s_t_e_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"d_i_r_e_c_t_c_o_n_n_e_c_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -183,7 +342,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"d_i_s_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"d_m_s_r_e_p_l_i_c_a_t_i_o_n": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -191,7 +366,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"d_m_s_r_e_p_l_i_c_a_t_i_o_n_t_a_s_k_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -199,7 +374,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"d_o_c_d_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -207,7 +382,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"d_y_n_a_m_o_d_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -215,7 +390,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_b_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -223,7 +398,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_c2": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -231,7 +406,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"e_c_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"e_c_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -239,7 +422,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_f_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -247,7 +430,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"e_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"e_l_a_s_t_i_c_a_c_h_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -255,7 +446,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_l_a_s_t_i_c_b_e_a_n_s_t_a_l_k": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -263,7 +454,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_l_a_s_t_i_c_s_e_a_r_c_h": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -271,7 +462,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_l_a_s_t_i_c_t_r_a_n_s_c_o_d_e_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -279,7 +470,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_l_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -287,7 +478,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_m_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -295,7 +486,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_v_e_n_t_b_r_id_g_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -303,7 +494,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"e_v_e_n_t_g_r_id": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"e_v_e_n_t_h_u_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -311,7 +510,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"e_x_p_r_e_s_s_r_o_u_t_e_c_i_r_c_ui_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -319,7 +518,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"f_i_l_e_s_t_o_r_a_g_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -327,7 +526,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"f_i_r_e_h_o_s_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -335,7 +534,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"f_i_r_e_w_a_l_l": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -343,7 +542,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"f_r_o_n_t_d_o_o_r_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -351,7 +550,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"f_s_x": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -359,7 +558,31 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"f_u_n_c_t_i_o_n": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"g_a_t_e_w_a_y_e_l_b": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"g_l_o_b_a_l_n_e_t_w_o_r_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"g_l_u_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -367,7 +590,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"h_d_i_n_s_i_g_h_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"i_o_t_h_u_b": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"k_e_y_v_a_u_l_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -375,7 +614,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"k_i_n_e_s_i_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -383,7 +622,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"k_i_n_e_s_i_s_v_id_e_o": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -391,7 +630,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"l_a_m_b_d_a": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -399,7 +638,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"l_o_a_d_b_a_l_a_n_c_e_r_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -407,7 +646,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"l_o_g_a_n_a_l_y_t_i_c_s_w_o_r_k_s_p_a_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -415,7 +654,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"l_o_g_i_c_a_p_p_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -423,7 +662,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"m_a_r_i_a_d_b": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"m_e_d_i_a_c_o_n_n_e_c_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -431,7 +678,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_e_d_i_a_c_o_n_v_e_r_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -439,7 +686,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_e_d_i_a_p_a_c_k_a_g_e_l_i_v_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -447,7 +694,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_e_d_i_a_p_a_c_k_a_g_e_v_o_d": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -455,7 +702,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_e_d_i_a_s_t_o_r_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -463,7 +710,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_e_d_i_a_t_a_i_l_o_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -471,7 +718,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"m_l_w_o_r_k_s_p_a_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"m_q": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -479,7 +734,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_s_k_b_r_o_k_e_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -487,7 +742,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_s_k_c_l_u_s_t_e_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -495,7 +750,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"m_y_sql": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -503,7 +758,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"m_y_sql_f_l_e_x_i_b_l_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"n_a_t_g_a_t_e_w_a_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -511,7 +774,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"n_a_t_g_a_t_e_w_a_y_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"n_e_t_a_p_p_p_o_o_l_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"n_e_t_w_o_r_k_e_l_b": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -519,7 +798,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -527,7 +806,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"o_p_e_n_a_i_s_e_r_v_i_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"o_p_s_w_o_r_k_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -535,7 +830,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"p_o_s_t_g_r_e_sql": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -543,7 +838,47 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"p_o_s_t_g_r_e_sql_c_i_t_u_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"p_o_w_e_r_b_i_e_m_b_e_d_d_e_d": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"p_u_b_l_i_c_ip": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -551,7 +886,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"q_b_u_s_i_n_e_s_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"q_u_e_u_e_s_t_o_r_a_g_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -559,7 +902,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"q_ui_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"q_ui_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"r_d_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -567,15 +926,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
-		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m": {
+		
+		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
 				Schema: CloudServiceSettingsSchema(),
 			},
 			Optional: true,
 		},
-
+		
 		"r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -583,7 +942,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"r_e_d_i_s_c_a_c_h_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -591,7 +950,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"r_e_d_s_h_i_f_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -599,7 +966,23 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
+		"r_e_l_a_y_n_a_m_e_s_p_a_c_e_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"r_o_u_t_e53": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -607,7 +990,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"r_o_u_t_e53_r_e_s_o_l_v_e_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -615,7 +1006,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s3": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -623,7 +1014,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_a_g_e_m_a_k_e_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -631,7 +1022,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_e_r_v_i_c_e_b_u_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -639,7 +1030,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"s_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -647,7 +1046,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"s_i_g_n_a_l_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"s_n_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -655,7 +1062,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"sql_d_a_t_a_b_a_s_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -663,7 +1070,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"sql_e_l_a_s_t_i_c_p_o_o_l": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -671,7 +1078,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"sql_m_a_n_a_g_e_d_i_n_s_t_a_n_c_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -679,7 +1086,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_q_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -687,7 +1094,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_t_e_p_f_u_n_c_t_i_o_n_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -695,7 +1102,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_t_o_r_a_g_e_a_c_c_o_u_n_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -703,7 +1110,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"s_t_r_e_a_m_a_n_a_l_y_t_i_c_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"s_w_f_a_c_t_i_v_i_t_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -711,7 +1126,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_w_f_w_o_r_k_f_l_o_w": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -719,7 +1134,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"s_y_n_a_p_s_e_w_o_r_k_s_p_a_c_e_s": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -727,7 +1142,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"t_a_b_l_e_s_t_o_r_a_g_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -735,7 +1150,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"t_r_a_f_f_i_c_m_a_n_a_g_e_r": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -743,7 +1158,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"t_r_a_n_s_f_e_r": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"t_r_a_n_s_i_t_g_a_t_e_w_a_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -751,7 +1174,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"v_i_r_t_u_a_l_d_e_s_k_t_o_p": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -759,7 +1190,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"v_i_r_t_u_a_l_h_u_b_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -767,7 +1206,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -775,7 +1214,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t_vm": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -783,7 +1222,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_g_a_t_e_w_a_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -791,7 +1230,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"v_p_n": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -799,7 +1246,15 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
+		"v_p_n_g_a_t_e_w_a_y_s": {
+			Type: schema.TypeList, //GoType: CloudServiceSettings
+			Elem: &schema.Resource{
+				Schema: CloudServiceSettingsSchema(),
+			},
+			Optional: true,
+		},
+		
 		"w_o_r_k_s_p_a_c_e": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -807,7 +1262,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
-
+		
 		"w_o_r_k_s_p_a_c_e_d_i_r_e_c_t_o_r_y": {
 			Type: schema.TypeList, //GoType: CloudServiceSettings
 			Elem: &schema.Resource{
@@ -815,6 +1270,7 @@ func CloudServicesSchema() map[string]*schema.Schema {
 			},
 			Optional: true,
 		},
+		
 	}
 }
 
@@ -822,36 +1278,60 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 	for _, cloudServices := range m {
 		if cloudServices != nil {
 			properties := make(map[string]interface{})
+			properties["a_c_m"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ACM})
+			properties["a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.AKSMANAGEDCLUSTER})
+			properties["a_l_a_r_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ALARMS})
+			properties["a_n_a_l_y_s_i_s_s_e_r_v_i_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ANALYSISSERVICE})
 			properties["api_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APIGATEWAY})
+			properties["api_g_a_t_e_w_a_y_v2"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APIGATEWAYV2})
 			properties["api_m_a_n_a_g_e_m_e_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APIMANAGEMENT})
 			properties["a_p_p_l_i_c_a_t_i_o_n_e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONELB})
 			properties["a_p_p_l_i_c_a_t_i_o_n_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONGATEWAY})
 			properties["a_p_p_l_i_c_a_t_i_o_n_i_n_s_i_g_h_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONINSIGHTS})
+			properties["a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPLICATIONMIGRATIONSERVICE})
 			properties["a_p_p_s_e_r_v_i_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSERVICE})
+			properties["a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSERVICEENVIRONMENT})
 			properties["a_p_p_s_e_r_v_i_c_e_p_l_a_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSERVICEPLAN})
 			properties["a_p_p_s_t_r_e_a_m"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.APPSTREAM})
 			properties["a_t_h_e_n_a"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ATHENA})
 			properties["a_u_t_o_m_a_t_i_o_n_a_c_c_o_u_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.AUTOMATIONACCOUNT})
 			properties["a_u_t_o_s_c_a_l_i_n_g"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.AUTOSCALING})
+			properties["b_a_c_k_u_p"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUP})
 			properties["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUPPROTECTEDITEMS})
+			properties["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BACKUPPROTECTEDRESOURCE})
+			properties["b_a_t_c_h_a_c_c_o_u_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BATCHACCOUNT})
+			properties["b_e_d_r_o_c_k"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BEDROCK})
 			properties["b_l_o_b_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BLOBSTORAGE})
+			properties["b_o_t_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.BOTSERVICES})
+			properties["c_d_n_p_r_o_f_i_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CDNPROFILE})
 			properties["c_l_o_u_d_f_r_o_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDFRONT})
 			properties["c_l_o_u_d_s_e_a_r_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CLOUDSEARCH})
 			properties["c_o_d_e_b_ui_l_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CODEBUILD})
 			properties["c_o_g_n_i_t_i_v_e_s_e_a_r_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COGNITIVESEARCH})
 			properties["c_o_g_n_i_t_i_v_e_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COGNITIVESERVICES})
 			properties["c_o_g_n_i_t_o"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COGNITO})
+			properties["c_o_n_t_a_i_n_e_r_a_p_p_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CONTAINERAPPS})
+			properties["c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CONTAINERINSTANCE})
+			properties["c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.CONTAINERREGISTRY})
 			properties["c_o_s_m_o_s_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.COSMOSDB})
+			properties["d_a_t_a_b_r_i_c_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATABRICKS})
 			properties["d_a_t_a_f_a_c_t_o_r_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATAFACTORY})
+			properties["d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATALAKEANALYTICS})
+			properties["d_a_t_a_l_a_k_e_s_t_o_r_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DATALAKESTORE})
+			properties["d_b_c_l_u_s_t_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DBCLUSTER})
 			properties["d_i_r_e_c_t_c_o_n_n_e_c_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DIRECTCONNECT})
+			properties["d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DIRECTCONNECTVIRTUALINTERFACE})
+			properties["d_i_s_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DISKS})
 			properties["d_m_s_r_e_p_l_i_c_a_t_i_o_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DMSREPLICATION})
 			properties["d_m_s_r_e_p_l_i_c_a_t_i_o_n_t_a_s_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DMSREPLICATIONTASKS})
 			properties["d_o_c_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DOCDB})
 			properties["d_y_n_a_m_o_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.DYNAMODB})
 			properties["e_b_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EBS})
 			properties["e_c2"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EC2})
+			properties["e_c_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ECR})
 			properties["e_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ECS})
 			properties["e_f_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EFS})
+			properties["e_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EKS})
 			properties["e_l_a_s_t_i_c_a_c_h_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICACHE})
 			properties["e_l_a_s_t_i_c_b_e_a_n_s_t_a_l_k"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICBEANSTALK})
 			properties["e_l_a_s_t_i_c_s_e_a_r_c_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELASTICSEARCH})
@@ -859,6 +1339,7 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ELB})
 			properties["e_m_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EMR})
 			properties["e_v_e_n_t_b_r_id_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EVENTBRIDGE})
+			properties["e_v_e_n_t_g_r_id"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EVENTGRID})
 			properties["e_v_e_n_t_h_u_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EVENTHUB})
 			properties["e_x_p_r_e_s_s_r_o_u_t_e_c_i_r_c_ui_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.EXPRESSROUTECIRCUIT})
 			properties["f_i_l_e_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FILESTORAGE})
@@ -866,7 +1347,12 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["f_i_r_e_w_a_l_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FIREWALL})
 			properties["f_r_o_n_t_d_o_o_r_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FRONTDOORS})
 			properties["f_s_x"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FSX})
+			properties["f_u_n_c_t_i_o_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.FUNCTION})
+			properties["g_a_t_e_w_a_y_e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.GATEWAYELB})
+			properties["g_l_o_b_a_l_n_e_t_w_o_r_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.GLOBALNETWORKS})
 			properties["g_l_u_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.GLUE})
+			properties["h_d_i_n_s_i_g_h_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.HDINSIGHT})
+			properties["i_o_t_h_u_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.IOTHUB})
 			properties["k_e_y_v_a_u_l_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KEYVAULT})
 			properties["k_i_n_e_s_i_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KINESIS})
 			properties["k_i_n_e_s_i_s_v_id_e_o"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.KINESISVIDEO})
@@ -874,34 +1360,55 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["l_o_a_d_b_a_l_a_n_c_e_r_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LOADBALANCERS})
 			properties["l_o_g_a_n_a_l_y_t_i_c_s_w_o_r_k_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LOGANALYTICSWORKSPACES})
 			properties["l_o_g_i_c_a_p_p_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.LOGICAPPS})
+			properties["m_a_r_i_a_d_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MARIADB})
 			properties["m_e_d_i_a_c_o_n_n_e_c_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIACONNECT})
 			properties["m_e_d_i_a_c_o_n_v_e_r_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIACONVERT})
 			properties["m_e_d_i_a_p_a_c_k_a_g_e_l_i_v_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIAPACKAGELIVE})
 			properties["m_e_d_i_a_p_a_c_k_a_g_e_v_o_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIAPACKAGEVOD})
 			properties["m_e_d_i_a_s_t_o_r_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIASTORE})
 			properties["m_e_d_i_a_t_a_i_l_o_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MEDIATAILOR})
+			properties["m_l_w_o_r_k_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MLWORKSPACES})
 			properties["m_q"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MQ})
 			properties["m_s_k_b_r_o_k_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MSKBROKER})
 			properties["m_s_k_c_l_u_s_t_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MSKCLUSTER})
 			properties["m_y_sql"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MYSQL})
+			properties["m_y_sql_f_l_e_x_i_b_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.MYSQLFLEXIBLE})
 			properties["n_a_t_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NATGATEWAY})
+			properties["n_a_t_g_a_t_e_w_a_y_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NATGATEWAYS})
+			properties["n_e_t_a_p_p_p_o_o_l_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETAPPPOOLS})
 			properties["n_e_t_w_o_r_k_e_l_b"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETWORKELB})
 			properties["n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NETWORKINTERFACE})
+			properties["n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.NOTIFICATIONHUBS})
+			properties["o_p_e_n_a_i_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.OPENAISERVICES})
 			properties["o_p_s_w_o_r_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.OPSWORKS})
 			properties["p_o_s_t_g_r_e_sql"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POSTGRESQL})
+			properties["p_o_s_t_g_r_e_sql_c_i_t_u_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POSTGRESQLCITUS})
+			properties["p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POSTGRESQLFLEXIBLE})
+			properties["p_o_w_e_r_b_i_e_m_b_e_d_d_e_d"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.POWERBIEMBEDDED})
+			properties["p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.PRIVATELINKENDPOINTS})
+			properties["p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.PRIVATELINKSERVICES})
 			properties["p_u_b_l_i_c_ip"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.PUBLICIP})
+			properties["q_b_u_s_i_n_e_s_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QBUSINESS})
 			properties["q_u_e_u_e_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUEUESTORAGE})
+			properties["q_ui_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUICKSIGHTDASHBOARDS})
+			properties["q_ui_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.QUICKSIGHTDATASETS})
 			properties["r_d_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RDS})
-			properties["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RECOVERYPROTECTEDITEM})
+			properties["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RECOVERYPROTECTEDITEMS})
 			properties["r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RECOVERYSERVICES})
 			properties["r_e_d_i_s_c_a_c_h_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDISCACHE})
+			properties["r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDISCACHEENTERPRISE})
 			properties["r_e_d_s_h_i_f_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDSHIFT})
+			properties["r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.REDSHIFTSERVERLESS})
+			properties["r_e_l_a_y_n_a_m_e_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.RELAYNAMESPACES})
 			properties["r_o_u_t_e53"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ROUTE53})
+			properties["r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ROUTE53HOSTEDZONE})
 			properties["r_o_u_t_e53_r_e_s_o_l_v_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.ROUTE53RESOLVER})
 			properties["s3"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.S3})
 			properties["s_a_g_e_m_a_k_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SAGEMAKER})
 			properties["s_e_r_v_i_c_e_b_u_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SERVICEBUS})
+			properties["s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SERVICEFABRICMESH})
 			properties["s_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SES})
+			properties["s_i_g_n_a_l_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SIGNALR})
 			properties["s_n_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SNS})
 			properties["sql_d_a_t_a_b_a_s_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SQLDATABASE})
 			properties["sql_e_l_a_s_t_i_c_p_o_o_l"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SQLELASTICPOOL})
@@ -909,18 +1416,24 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 			properties["s_q_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SQS})
 			properties["s_t_e_p_f_u_n_c_t_i_o_n_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STEPFUNCTIONS})
 			properties["s_t_o_r_a_g_e_a_c_c_o_u_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STORAGEACCOUNT})
+			properties["s_t_r_e_a_m_a_n_a_l_y_t_i_c_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.STREAMANALYTICS})
 			properties["s_w_f_a_c_t_i_v_i_t_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SWFACTIVITY})
 			properties["s_w_f_w_o_r_k_f_l_o_w"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SWFWORKFLOW})
 			properties["s_y_n_a_p_s_e_w_o_r_k_s_p_a_c_e_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.SYNAPSEWORKSPACES})
 			properties["t_a_b_l_e_s_t_o_r_a_g_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TABLESTORAGE})
 			properties["t_r_a_f_f_i_c_m_a_n_a_g_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRAFFICMANAGER})
+			properties["t_r_a_n_s_f_e_r"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRANSFER})
 			properties["t_r_a_n_s_i_t_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRANSITGATEWAY})
+			properties["t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.TRANSITGATEWAYATTACHMENT})
 			properties["v_i_r_t_u_a_l_d_e_s_k_t_o_p"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALDESKTOP})
+			properties["v_i_r_t_u_a_l_h_u_b_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALHUBS})
 			properties["v_i_r_t_u_a_l_m_a_c_h_i_n_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALMACHINE})
 			properties["v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALMACHINESCALESET})
 			properties["v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t_vm"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALMACHINESCALESETVM})
 			properties["v_i_r_t_u_a_l_n_e_t_w_o_r_k_g_a_t_e_w_a_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALNETWORKGATEWAY})
+			properties["v_i_r_t_u_a_l_n_e_t_w_o_r_k_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VIRTUALNETWORKS})
 			properties["v_p_n"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPN})
+			properties["v_p_n_g_a_t_e_w_a_y_s"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.VPNGATEWAYS})
 			properties["w_o_r_k_s_p_a_c_e"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.WORKSPACE})
 			properties["w_o_r_k_s_p_a_c_e_d_i_r_e_c_t_o_r_y"] = SetCloudServiceSettingsSubResourceData([]*models.CloudServiceSettings{cloudServices.WORKSPACEDIRECTORY})
 			d = append(d, &properties)
@@ -931,10 +1444,35 @@ func SetCloudServicesSubResourceData(m []*models.CloudServices) (d []*map[string
 
 func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	// assume that the incoming map only contains the relevant resource data
+	var aCM *models.CloudServiceSettings = nil
+	ACMList := d["a_c_m"].([]interface{})
+	if len(ACMList) > 0 { // len(nil) = 0
+		aCM = CloudServiceSettingsModel(ACMList[0].(map[string]interface{}))
+	}
+	var aKSMANAGEDCLUSTER *models.CloudServiceSettings = nil
+	AKSMANAGEDCLUSTERList := d["a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r"].([]interface{})
+	if len(AKSMANAGEDCLUSTERList) > 0 { // len(nil) = 0
+		aKSMANAGEDCLUSTER = CloudServiceSettingsModel(AKSMANAGEDCLUSTERList[0].(map[string]interface{}))
+	}
+	var aLARMS *models.CloudServiceSettings = nil
+	ALARMSList := d["a_l_a_r_m_s"].([]interface{})
+	if len(ALARMSList) > 0 { // len(nil) = 0
+		aLARMS = CloudServiceSettingsModel(ALARMSList[0].(map[string]interface{}))
+	}
+	var aNALYSISSERVICE *models.CloudServiceSettings = nil
+	ANALYSISSERVICEList := d["a_n_a_l_y_s_i_s_s_e_r_v_i_c_e"].([]interface{})
+	if len(ANALYSISSERVICEList) > 0 { // len(nil) = 0
+		aNALYSISSERVICE = CloudServiceSettingsModel(ANALYSISSERVICEList[0].(map[string]interface{}))
+	}
 	var aPIGATEWAY *models.CloudServiceSettings = nil
 	APIGATEWAYList := d["api_g_a_t_e_w_a_y"].([]interface{})
 	if len(APIGATEWAYList) > 0 { // len(nil) = 0
 		aPIGATEWAY = CloudServiceSettingsModel(APIGATEWAYList[0].(map[string]interface{}))
+	}
+	var aPIGATEWAYV2 *models.CloudServiceSettings = nil
+	APIGATEWAYV2List := d["api_g_a_t_e_w_a_y_v2"].([]interface{})
+	if len(APIGATEWAYV2List) > 0 { // len(nil) = 0
+		aPIGATEWAYV2 = CloudServiceSettingsModel(APIGATEWAYV2List[0].(map[string]interface{}))
 	}
 	var aPIMANAGEMENT *models.CloudServiceSettings = nil
 	APIMANAGEMENTList := d["api_m_a_n_a_g_e_m_e_n_t"].([]interface{})
@@ -956,10 +1494,20 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(APPLICATIONINSIGHTSList) > 0 { // len(nil) = 0
 		aPPLICATIONINSIGHTS = CloudServiceSettingsModel(APPLICATIONINSIGHTSList[0].(map[string]interface{}))
 	}
+	var aPPLICATIONMIGRATIONSERVICE *models.CloudServiceSettings = nil
+	APPLICATIONMIGRATIONSERVICEList := d["a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e"].([]interface{})
+	if len(APPLICATIONMIGRATIONSERVICEList) > 0 { // len(nil) = 0
+		aPPLICATIONMIGRATIONSERVICE = CloudServiceSettingsModel(APPLICATIONMIGRATIONSERVICEList[0].(map[string]interface{}))
+	}
 	var aPPSERVICE *models.CloudServiceSettings = nil
 	APPSERVICEList := d["a_p_p_s_e_r_v_i_c_e"].([]interface{})
 	if len(APPSERVICEList) > 0 { // len(nil) = 0
 		aPPSERVICE = CloudServiceSettingsModel(APPSERVICEList[0].(map[string]interface{}))
+	}
+	var aPPSERVICEENVIRONMENT *models.CloudServiceSettings = nil
+	APPSERVICEENVIRONMENTList := d["a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t"].([]interface{})
+	if len(APPSERVICEENVIRONMENTList) > 0 { // len(nil) = 0
+		aPPSERVICEENVIRONMENT = CloudServiceSettingsModel(APPSERVICEENVIRONMENTList[0].(map[string]interface{}))
 	}
 	var aPPSERVICEPLAN *models.CloudServiceSettings = nil
 	APPSERVICEPLANList := d["a_p_p_s_e_r_v_i_c_e_p_l_a_n"].([]interface{})
@@ -986,15 +1534,45 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(AUTOSCALINGList) > 0 { // len(nil) = 0
 		aUTOSCALING = CloudServiceSettingsModel(AUTOSCALINGList[0].(map[string]interface{}))
 	}
+	var bACKUP *models.CloudServiceSettings = nil
+	BACKUPList := d["b_a_c_k_u_p"].([]interface{})
+	if len(BACKUPList) > 0 { // len(nil) = 0
+		bACKUP = CloudServiceSettingsModel(BACKUPList[0].(map[string]interface{}))
+	}
 	var bACKUPPROTECTEDITEMS *models.CloudServiceSettings = nil
 	BACKUPPROTECTEDITEMSList := d["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s"].([]interface{})
 	if len(BACKUPPROTECTEDITEMSList) > 0 { // len(nil) = 0
 		bACKUPPROTECTEDITEMS = CloudServiceSettingsModel(BACKUPPROTECTEDITEMSList[0].(map[string]interface{}))
 	}
+	var bACKUPPROTECTEDRESOURCE *models.CloudServiceSettings = nil
+	BACKUPPROTECTEDRESOURCEList := d["b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e"].([]interface{})
+	if len(BACKUPPROTECTEDRESOURCEList) > 0 { // len(nil) = 0
+		bACKUPPROTECTEDRESOURCE = CloudServiceSettingsModel(BACKUPPROTECTEDRESOURCEList[0].(map[string]interface{}))
+	}
+	var bATCHACCOUNT *models.CloudServiceSettings = nil
+	BATCHACCOUNTList := d["b_a_t_c_h_a_c_c_o_u_n_t"].([]interface{})
+	if len(BATCHACCOUNTList) > 0 { // len(nil) = 0
+		bATCHACCOUNT = CloudServiceSettingsModel(BATCHACCOUNTList[0].(map[string]interface{}))
+	}
+	var bEDROCK *models.CloudServiceSettings = nil
+	BEDROCKList := d["b_e_d_r_o_c_k"].([]interface{})
+	if len(BEDROCKList) > 0 { // len(nil) = 0
+		bEDROCK = CloudServiceSettingsModel(BEDROCKList[0].(map[string]interface{}))
+	}
 	var bLOBSTORAGE *models.CloudServiceSettings = nil
 	BLOBSTORAGEList := d["b_l_o_b_s_t_o_r_a_g_e"].([]interface{})
 	if len(BLOBSTORAGEList) > 0 { // len(nil) = 0
 		bLOBSTORAGE = CloudServiceSettingsModel(BLOBSTORAGEList[0].(map[string]interface{}))
+	}
+	var bOTSERVICES *models.CloudServiceSettings = nil
+	BOTSERVICESList := d["b_o_t_s_e_r_v_i_c_e_s"].([]interface{})
+	if len(BOTSERVICESList) > 0 { // len(nil) = 0
+		bOTSERVICES = CloudServiceSettingsModel(BOTSERVICESList[0].(map[string]interface{}))
+	}
+	var cDNPROFILE *models.CloudServiceSettings = nil
+	CDNPROFILEList := d["c_d_n_p_r_o_f_i_l_e"].([]interface{})
+	if len(CDNPROFILEList) > 0 { // len(nil) = 0
+		cDNPROFILE = CloudServiceSettingsModel(CDNPROFILEList[0].(map[string]interface{}))
 	}
 	var cLOUDFRONT *models.CloudServiceSettings = nil
 	CLOUDFRONTList := d["c_l_o_u_d_f_r_o_n_t"].([]interface{})
@@ -1026,20 +1604,65 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(COGNITOList) > 0 { // len(nil) = 0
 		cOGNITO = CloudServiceSettingsModel(COGNITOList[0].(map[string]interface{}))
 	}
+	var cONTAINERAPPS *models.CloudServiceSettings = nil
+	CONTAINERAPPSList := d["c_o_n_t_a_i_n_e_r_a_p_p_s"].([]interface{})
+	if len(CONTAINERAPPSList) > 0 { // len(nil) = 0
+		cONTAINERAPPS = CloudServiceSettingsModel(CONTAINERAPPSList[0].(map[string]interface{}))
+	}
+	var cONTAINERINSTANCE *models.CloudServiceSettings = nil
+	CONTAINERINSTANCEList := d["c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e"].([]interface{})
+	if len(CONTAINERINSTANCEList) > 0 { // len(nil) = 0
+		cONTAINERINSTANCE = CloudServiceSettingsModel(CONTAINERINSTANCEList[0].(map[string]interface{}))
+	}
+	var cONTAINERREGISTRY *models.CloudServiceSettings = nil
+	CONTAINERREGISTRYList := d["c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y"].([]interface{})
+	if len(CONTAINERREGISTRYList) > 0 { // len(nil) = 0
+		cONTAINERREGISTRY = CloudServiceSettingsModel(CONTAINERREGISTRYList[0].(map[string]interface{}))
+	}
 	var cOSMOSDB *models.CloudServiceSettings = nil
 	COSMOSDBList := d["c_o_s_m_o_s_d_b"].([]interface{})
 	if len(COSMOSDBList) > 0 { // len(nil) = 0
 		cOSMOSDB = CloudServiceSettingsModel(COSMOSDBList[0].(map[string]interface{}))
+	}
+	var dATABRICKS *models.CloudServiceSettings = nil
+	DATABRICKSList := d["d_a_t_a_b_r_i_c_k_s"].([]interface{})
+	if len(DATABRICKSList) > 0 { // len(nil) = 0
+		dATABRICKS = CloudServiceSettingsModel(DATABRICKSList[0].(map[string]interface{}))
 	}
 	var dATAFACTORY *models.CloudServiceSettings = nil
 	DATAFACTORYList := d["d_a_t_a_f_a_c_t_o_r_y"].([]interface{})
 	if len(DATAFACTORYList) > 0 { // len(nil) = 0
 		dATAFACTORY = CloudServiceSettingsModel(DATAFACTORYList[0].(map[string]interface{}))
 	}
+	var dATALAKEANALYTICS *models.CloudServiceSettings = nil
+	DATALAKEANALYTICSList := d["d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s"].([]interface{})
+	if len(DATALAKEANALYTICSList) > 0 { // len(nil) = 0
+		dATALAKEANALYTICS = CloudServiceSettingsModel(DATALAKEANALYTICSList[0].(map[string]interface{}))
+	}
+	var dATALAKESTORE *models.CloudServiceSettings = nil
+	DATALAKESTOREList := d["d_a_t_a_l_a_k_e_s_t_o_r_e"].([]interface{})
+	if len(DATALAKESTOREList) > 0 { // len(nil) = 0
+		dATALAKESTORE = CloudServiceSettingsModel(DATALAKESTOREList[0].(map[string]interface{}))
+	}
+	var dBCLUSTER *models.CloudServiceSettings = nil
+	DBCLUSTERList := d["d_b_c_l_u_s_t_e_r"].([]interface{})
+	if len(DBCLUSTERList) > 0 { // len(nil) = 0
+		dBCLUSTER = CloudServiceSettingsModel(DBCLUSTERList[0].(map[string]interface{}))
+	}
 	var dIRECTCONNECT *models.CloudServiceSettings = nil
 	DIRECTCONNECTList := d["d_i_r_e_c_t_c_o_n_n_e_c_t"].([]interface{})
 	if len(DIRECTCONNECTList) > 0 { // len(nil) = 0
 		dIRECTCONNECT = CloudServiceSettingsModel(DIRECTCONNECTList[0].(map[string]interface{}))
+	}
+	var dIRECTCONNECTVIRTUALINTERFACE *models.CloudServiceSettings = nil
+	DIRECTCONNECTVIRTUALINTERFACEList := d["d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e"].([]interface{})
+	if len(DIRECTCONNECTVIRTUALINTERFACEList) > 0 { // len(nil) = 0
+		dIRECTCONNECTVIRTUALINTERFACE = CloudServiceSettingsModel(DIRECTCONNECTVIRTUALINTERFACEList[0].(map[string]interface{}))
+	}
+	var dISKS *models.CloudServiceSettings = nil
+	DISKSList := d["d_i_s_k_s"].([]interface{})
+	if len(DISKSList) > 0 { // len(nil) = 0
+		dISKS = CloudServiceSettingsModel(DISKSList[0].(map[string]interface{}))
 	}
 	var dMSREPLICATION *models.CloudServiceSettings = nil
 	DMSREPLICATIONList := d["d_m_s_r_e_p_l_i_c_a_t_i_o_n"].([]interface{})
@@ -1071,6 +1694,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(EC2List) > 0 { // len(nil) = 0
 		eC2 = CloudServiceSettingsModel(EC2List[0].(map[string]interface{}))
 	}
+	var eCR *models.CloudServiceSettings = nil
+	ECRList := d["e_c_r"].([]interface{})
+	if len(ECRList) > 0 { // len(nil) = 0
+		eCR = CloudServiceSettingsModel(ECRList[0].(map[string]interface{}))
+	}
 	var eCS *models.CloudServiceSettings = nil
 	ECSList := d["e_c_s"].([]interface{})
 	if len(ECSList) > 0 { // len(nil) = 0
@@ -1080,6 +1708,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	EFSList := d["e_f_s"].([]interface{})
 	if len(EFSList) > 0 { // len(nil) = 0
 		eFS = CloudServiceSettingsModel(EFSList[0].(map[string]interface{}))
+	}
+	var eKS *models.CloudServiceSettings = nil
+	EKSList := d["e_k_s"].([]interface{})
+	if len(EKSList) > 0 { // len(nil) = 0
+		eKS = CloudServiceSettingsModel(EKSList[0].(map[string]interface{}))
 	}
 	var eLASTICACHE *models.CloudServiceSettings = nil
 	ELASTICACHEList := d["e_l_a_s_t_i_c_a_c_h_e"].([]interface{})
@@ -1116,6 +1749,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(EVENTBRIDGEList) > 0 { // len(nil) = 0
 		eVENTBRIDGE = CloudServiceSettingsModel(EVENTBRIDGEList[0].(map[string]interface{}))
 	}
+	var eVENTGRID *models.CloudServiceSettings = nil
+	EVENTGRIDList := d["e_v_e_n_t_g_r_id"].([]interface{})
+	if len(EVENTGRIDList) > 0 { // len(nil) = 0
+		eVENTGRID = CloudServiceSettingsModel(EVENTGRIDList[0].(map[string]interface{}))
+	}
 	var eVENTHUB *models.CloudServiceSettings = nil
 	EVENTHUBList := d["e_v_e_n_t_h_u_b"].([]interface{})
 	if len(EVENTHUBList) > 0 { // len(nil) = 0
@@ -1151,10 +1789,35 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(FSXList) > 0 { // len(nil) = 0
 		fSX = CloudServiceSettingsModel(FSXList[0].(map[string]interface{}))
 	}
+	var fUNCTION *models.CloudServiceSettings = nil
+	FUNCTIONList := d["f_u_n_c_t_i_o_n"].([]interface{})
+	if len(FUNCTIONList) > 0 { // len(nil) = 0
+		fUNCTION = CloudServiceSettingsModel(FUNCTIONList[0].(map[string]interface{}))
+	}
+	var gATEWAYELB *models.CloudServiceSettings = nil
+	GATEWAYELBList := d["g_a_t_e_w_a_y_e_l_b"].([]interface{})
+	if len(GATEWAYELBList) > 0 { // len(nil) = 0
+		gATEWAYELB = CloudServiceSettingsModel(GATEWAYELBList[0].(map[string]interface{}))
+	}
+	var gLOBALNETWORKS *models.CloudServiceSettings = nil
+	GLOBALNETWORKSList := d["g_l_o_b_a_l_n_e_t_w_o_r_k_s"].([]interface{})
+	if len(GLOBALNETWORKSList) > 0 { // len(nil) = 0
+		gLOBALNETWORKS = CloudServiceSettingsModel(GLOBALNETWORKSList[0].(map[string]interface{}))
+	}
 	var gLUE *models.CloudServiceSettings = nil
 	GLUEList := d["g_l_u_e"].([]interface{})
 	if len(GLUEList) > 0 { // len(nil) = 0
 		gLUE = CloudServiceSettingsModel(GLUEList[0].(map[string]interface{}))
+	}
+	var hDINSIGHT *models.CloudServiceSettings = nil
+	HDINSIGHTList := d["h_d_i_n_s_i_g_h_t"].([]interface{})
+	if len(HDINSIGHTList) > 0 { // len(nil) = 0
+		hDINSIGHT = CloudServiceSettingsModel(HDINSIGHTList[0].(map[string]interface{}))
+	}
+	var iOTHUB *models.CloudServiceSettings = nil
+	IOTHUBList := d["i_o_t_h_u_b"].([]interface{})
+	if len(IOTHUBList) > 0 { // len(nil) = 0
+		iOTHUB = CloudServiceSettingsModel(IOTHUBList[0].(map[string]interface{}))
 	}
 	var kEYVAULT *models.CloudServiceSettings = nil
 	KEYVAULTList := d["k_e_y_v_a_u_l_t"].([]interface{})
@@ -1191,6 +1854,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(LOGICAPPSList) > 0 { // len(nil) = 0
 		lOGICAPPS = CloudServiceSettingsModel(LOGICAPPSList[0].(map[string]interface{}))
 	}
+	var mARIADB *models.CloudServiceSettings = nil
+	MARIADBList := d["m_a_r_i_a_d_b"].([]interface{})
+	if len(MARIADBList) > 0 { // len(nil) = 0
+		mARIADB = CloudServiceSettingsModel(MARIADBList[0].(map[string]interface{}))
+	}
 	var mEDIACONNECT *models.CloudServiceSettings = nil
 	MEDIACONNECTList := d["m_e_d_i_a_c_o_n_n_e_c_t"].([]interface{})
 	if len(MEDIACONNECTList) > 0 { // len(nil) = 0
@@ -1221,6 +1889,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(MEDIATAILORList) > 0 { // len(nil) = 0
 		mEDIATAILOR = CloudServiceSettingsModel(MEDIATAILORList[0].(map[string]interface{}))
 	}
+	var mLWORKSPACES *models.CloudServiceSettings = nil
+	MLWORKSPACESList := d["m_l_w_o_r_k_s_p_a_c_e_s"].([]interface{})
+	if len(MLWORKSPACESList) > 0 { // len(nil) = 0
+		mLWORKSPACES = CloudServiceSettingsModel(MLWORKSPACESList[0].(map[string]interface{}))
+	}
 	var mQ *models.CloudServiceSettings = nil
 	MQList := d["m_q"].([]interface{})
 	if len(MQList) > 0 { // len(nil) = 0
@@ -1241,10 +1914,25 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(MYSQLList) > 0 { // len(nil) = 0
 		mYSQL = CloudServiceSettingsModel(MYSQLList[0].(map[string]interface{}))
 	}
+	var mYSQLFLEXIBLE *models.CloudServiceSettings = nil
+	MYSQLFLEXIBLEList := d["m_y_sql_f_l_e_x_i_b_l_e"].([]interface{})
+	if len(MYSQLFLEXIBLEList) > 0 { // len(nil) = 0
+		mYSQLFLEXIBLE = CloudServiceSettingsModel(MYSQLFLEXIBLEList[0].(map[string]interface{}))
+	}
 	var nATGATEWAY *models.CloudServiceSettings = nil
 	NATGATEWAYList := d["n_a_t_g_a_t_e_w_a_y"].([]interface{})
 	if len(NATGATEWAYList) > 0 { // len(nil) = 0
 		nATGATEWAY = CloudServiceSettingsModel(NATGATEWAYList[0].(map[string]interface{}))
+	}
+	var nATGATEWAYS *models.CloudServiceSettings = nil
+	NATGATEWAYSList := d["n_a_t_g_a_t_e_w_a_y_s"].([]interface{})
+	if len(NATGATEWAYSList) > 0 { // len(nil) = 0
+		nATGATEWAYS = CloudServiceSettingsModel(NATGATEWAYSList[0].(map[string]interface{}))
+	}
+	var nETAPPPOOLS *models.CloudServiceSettings = nil
+	NETAPPPOOLSList := d["n_e_t_a_p_p_p_o_o_l_s"].([]interface{})
+	if len(NETAPPPOOLSList) > 0 { // len(nil) = 0
+		nETAPPPOOLS = CloudServiceSettingsModel(NETAPPPOOLSList[0].(map[string]interface{}))
 	}
 	var nETWORKELB *models.CloudServiceSettings = nil
 	NETWORKELBList := d["n_e_t_w_o_r_k_e_l_b"].([]interface{})
@@ -1256,6 +1944,16 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(NETWORKINTERFACEList) > 0 { // len(nil) = 0
 		nETWORKINTERFACE = CloudServiceSettingsModel(NETWORKINTERFACEList[0].(map[string]interface{}))
 	}
+	var nOTIFICATIONHUBS *models.CloudServiceSettings = nil
+	NOTIFICATIONHUBSList := d["n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s"].([]interface{})
+	if len(NOTIFICATIONHUBSList) > 0 { // len(nil) = 0
+		nOTIFICATIONHUBS = CloudServiceSettingsModel(NOTIFICATIONHUBSList[0].(map[string]interface{}))
+	}
+	var oPENAISERVICES *models.CloudServiceSettings = nil
+	OPENAISERVICESList := d["o_p_e_n_a_i_s_e_r_v_i_c_e_s"].([]interface{})
+	if len(OPENAISERVICESList) > 0 { // len(nil) = 0
+		oPENAISERVICES = CloudServiceSettingsModel(OPENAISERVICESList[0].(map[string]interface{}))
+	}
 	var oPSWORKS *models.CloudServiceSettings = nil
 	OPSWORKSList := d["o_p_s_w_o_r_k_s"].([]interface{})
 	if len(OPSWORKSList) > 0 { // len(nil) = 0
@@ -1266,25 +1964,65 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(POSTGRESQLList) > 0 { // len(nil) = 0
 		pOSTGRESQL = CloudServiceSettingsModel(POSTGRESQLList[0].(map[string]interface{}))
 	}
+	var pOSTGRESQLCITUS *models.CloudServiceSettings = nil
+	POSTGRESQLCITUSList := d["p_o_s_t_g_r_e_sql_c_i_t_u_s"].([]interface{})
+	if len(POSTGRESQLCITUSList) > 0 { // len(nil) = 0
+		pOSTGRESQLCITUS = CloudServiceSettingsModel(POSTGRESQLCITUSList[0].(map[string]interface{}))
+	}
+	var pOSTGRESQLFLEXIBLE *models.CloudServiceSettings = nil
+	POSTGRESQLFLEXIBLEList := d["p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e"].([]interface{})
+	if len(POSTGRESQLFLEXIBLEList) > 0 { // len(nil) = 0
+		pOSTGRESQLFLEXIBLE = CloudServiceSettingsModel(POSTGRESQLFLEXIBLEList[0].(map[string]interface{}))
+	}
+	var pOWERBIEMBEDDED *models.CloudServiceSettings = nil
+	POWERBIEMBEDDEDList := d["p_o_w_e_r_b_i_e_m_b_e_d_d_e_d"].([]interface{})
+	if len(POWERBIEMBEDDEDList) > 0 { // len(nil) = 0
+		pOWERBIEMBEDDED = CloudServiceSettingsModel(POWERBIEMBEDDEDList[0].(map[string]interface{}))
+	}
+	var pRIVATELINKENDPOINTS *models.CloudServiceSettings = nil
+	PRIVATELINKENDPOINTSList := d["p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s"].([]interface{})
+	if len(PRIVATELINKENDPOINTSList) > 0 { // len(nil) = 0
+		pRIVATELINKENDPOINTS = CloudServiceSettingsModel(PRIVATELINKENDPOINTSList[0].(map[string]interface{}))
+	}
+	var pRIVATELINKSERVICES *models.CloudServiceSettings = nil
+	PRIVATELINKSERVICESList := d["p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s"].([]interface{})
+	if len(PRIVATELINKSERVICESList) > 0 { // len(nil) = 0
+		pRIVATELINKSERVICES = CloudServiceSettingsModel(PRIVATELINKSERVICESList[0].(map[string]interface{}))
+	}
 	var pUBLICIP *models.CloudServiceSettings = nil
 	PUBLICIPList := d["p_u_b_l_i_c_ip"].([]interface{})
 	if len(PUBLICIPList) > 0 { // len(nil) = 0
 		pUBLICIP = CloudServiceSettingsModel(PUBLICIPList[0].(map[string]interface{}))
+	}
+	var qBUSINESS *models.CloudServiceSettings = nil
+	QBUSINESSList := d["q_b_u_s_i_n_e_s_s"].([]interface{})
+	if len(QBUSINESSList) > 0 { // len(nil) = 0
+		qBUSINESS = CloudServiceSettingsModel(QBUSINESSList[0].(map[string]interface{}))
 	}
 	var qUEUESTORAGE *models.CloudServiceSettings = nil
 	QUEUESTORAGEList := d["q_u_e_u_e_s_t_o_r_a_g_e"].([]interface{})
 	if len(QUEUESTORAGEList) > 0 { // len(nil) = 0
 		qUEUESTORAGE = CloudServiceSettingsModel(QUEUESTORAGEList[0].(map[string]interface{}))
 	}
+	var qUICKSIGHTDASHBOARDS *models.CloudServiceSettings = nil
+	QUICKSIGHTDASHBOARDSList := d["q_ui_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s"].([]interface{})
+	if len(QUICKSIGHTDASHBOARDSList) > 0 { // len(nil) = 0
+		qUICKSIGHTDASHBOARDS = CloudServiceSettingsModel(QUICKSIGHTDASHBOARDSList[0].(map[string]interface{}))
+	}
+	var qUICKSIGHTDATASETS *models.CloudServiceSettings = nil
+	QUICKSIGHTDATASETSList := d["q_ui_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s"].([]interface{})
+	if len(QUICKSIGHTDATASETSList) > 0 { // len(nil) = 0
+		qUICKSIGHTDATASETS = CloudServiceSettingsModel(QUICKSIGHTDATASETSList[0].(map[string]interface{}))
+	}
 	var rDS *models.CloudServiceSettings = nil
 	RDSList := d["r_d_s"].([]interface{})
 	if len(RDSList) > 0 { // len(nil) = 0
 		rDS = CloudServiceSettingsModel(RDSList[0].(map[string]interface{}))
 	}
-	var rECOVERYPROTECTEDITEM *models.CloudServiceSettings = nil
-	RECOVERYPROTECTEDITEMList := d["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m"].([]interface{})
-	if len(RECOVERYPROTECTEDITEMList) > 0 { // len(nil) = 0
-		rECOVERYPROTECTEDITEM = CloudServiceSettingsModel(RECOVERYPROTECTEDITEMList[0].(map[string]interface{}))
+	var rECOVERYPROTECTEDITEMS *models.CloudServiceSettings = nil
+	RECOVERYPROTECTEDITEMSList := d["r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s"].([]interface{})
+	if len(RECOVERYPROTECTEDITEMSList) > 0 { // len(nil) = 0
+		rECOVERYPROTECTEDITEMS = CloudServiceSettingsModel(RECOVERYPROTECTEDITEMSList[0].(map[string]interface{}))
 	}
 	var rECOVERYSERVICES *models.CloudServiceSettings = nil
 	RECOVERYSERVICESList := d["r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s"].([]interface{})
@@ -1296,15 +2034,35 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(REDISCACHEList) > 0 { // len(nil) = 0
 		rEDISCACHE = CloudServiceSettingsModel(REDISCACHEList[0].(map[string]interface{}))
 	}
+	var rEDISCACHEENTERPRISE *models.CloudServiceSettings = nil
+	REDISCACHEENTERPRISEList := d["r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e"].([]interface{})
+	if len(REDISCACHEENTERPRISEList) > 0 { // len(nil) = 0
+		rEDISCACHEENTERPRISE = CloudServiceSettingsModel(REDISCACHEENTERPRISEList[0].(map[string]interface{}))
+	}
 	var rEDSHIFT *models.CloudServiceSettings = nil
 	REDSHIFTList := d["r_e_d_s_h_i_f_t"].([]interface{})
 	if len(REDSHIFTList) > 0 { // len(nil) = 0
 		rEDSHIFT = CloudServiceSettingsModel(REDSHIFTList[0].(map[string]interface{}))
 	}
+	var rEDSHIFTSERVERLESS *models.CloudServiceSettings = nil
+	REDSHIFTSERVERLESSList := d["r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s"].([]interface{})
+	if len(REDSHIFTSERVERLESSList) > 0 { // len(nil) = 0
+		rEDSHIFTSERVERLESS = CloudServiceSettingsModel(REDSHIFTSERVERLESSList[0].(map[string]interface{}))
+	}
+	var rELAYNAMESPACES *models.CloudServiceSettings = nil
+	RELAYNAMESPACESList := d["r_e_l_a_y_n_a_m_e_s_p_a_c_e_s"].([]interface{})
+	if len(RELAYNAMESPACESList) > 0 { // len(nil) = 0
+		rELAYNAMESPACES = CloudServiceSettingsModel(RELAYNAMESPACESList[0].(map[string]interface{}))
+	}
 	var rOUTE53 *models.CloudServiceSettings = nil
 	ROUTE53List := d["r_o_u_t_e53"].([]interface{})
 	if len(ROUTE53List) > 0 { // len(nil) = 0
 		rOUTE53 = CloudServiceSettingsModel(ROUTE53List[0].(map[string]interface{}))
+	}
+	var rOUTE53HOSTEDZONE *models.CloudServiceSettings = nil
+	ROUTE53HOSTEDZONEList := d["r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e"].([]interface{})
+	if len(ROUTE53HOSTEDZONEList) > 0 { // len(nil) = 0
+		rOUTE53HOSTEDZONE = CloudServiceSettingsModel(ROUTE53HOSTEDZONEList[0].(map[string]interface{}))
 	}
 	var rOUTE53RESOLVER *models.CloudServiceSettings = nil
 	ROUTE53RESOLVERList := d["r_o_u_t_e53_r_e_s_o_l_v_e_r"].([]interface{})
@@ -1326,10 +2084,20 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(SERVICEBUSList) > 0 { // len(nil) = 0
 		sERVICEBUS = CloudServiceSettingsModel(SERVICEBUSList[0].(map[string]interface{}))
 	}
+	var sERVICEFABRICMESH *models.CloudServiceSettings = nil
+	SERVICEFABRICMESHList := d["s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h"].([]interface{})
+	if len(SERVICEFABRICMESHList) > 0 { // len(nil) = 0
+		sERVICEFABRICMESH = CloudServiceSettingsModel(SERVICEFABRICMESHList[0].(map[string]interface{}))
+	}
 	var sES *models.CloudServiceSettings = nil
 	SESList := d["s_e_s"].([]interface{})
 	if len(SESList) > 0 { // len(nil) = 0
 		sES = CloudServiceSettingsModel(SESList[0].(map[string]interface{}))
+	}
+	var sIGNALR *models.CloudServiceSettings = nil
+	SIGNALRList := d["s_i_g_n_a_l_r"].([]interface{})
+	if len(SIGNALRList) > 0 { // len(nil) = 0
+		sIGNALR = CloudServiceSettingsModel(SIGNALRList[0].(map[string]interface{}))
 	}
 	var sNS *models.CloudServiceSettings = nil
 	SNSList := d["s_n_s"].([]interface{})
@@ -1366,6 +2134,11 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(STORAGEACCOUNTList) > 0 { // len(nil) = 0
 		sTORAGEACCOUNT = CloudServiceSettingsModel(STORAGEACCOUNTList[0].(map[string]interface{}))
 	}
+	var sTREAMANALYTICS *models.CloudServiceSettings = nil
+	STREAMANALYTICSList := d["s_t_r_e_a_m_a_n_a_l_y_t_i_c_s"].([]interface{})
+	if len(STREAMANALYTICSList) > 0 { // len(nil) = 0
+		sTREAMANALYTICS = CloudServiceSettingsModel(STREAMANALYTICSList[0].(map[string]interface{}))
+	}
 	var sWFACTIVITY *models.CloudServiceSettings = nil
 	SWFACTIVITYList := d["s_w_f_a_c_t_i_v_i_t_y"].([]interface{})
 	if len(SWFACTIVITYList) > 0 { // len(nil) = 0
@@ -1391,15 +2164,30 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(TRAFFICMANAGERList) > 0 { // len(nil) = 0
 		tRAFFICMANAGER = CloudServiceSettingsModel(TRAFFICMANAGERList[0].(map[string]interface{}))
 	}
+	var tRANSFER *models.CloudServiceSettings = nil
+	TRANSFERList := d["t_r_a_n_s_f_e_r"].([]interface{})
+	if len(TRANSFERList) > 0 { // len(nil) = 0
+		tRANSFER = CloudServiceSettingsModel(TRANSFERList[0].(map[string]interface{}))
+	}
 	var tRANSITGATEWAY *models.CloudServiceSettings = nil
 	TRANSITGATEWAYList := d["t_r_a_n_s_i_t_g_a_t_e_w_a_y"].([]interface{})
 	if len(TRANSITGATEWAYList) > 0 { // len(nil) = 0
 		tRANSITGATEWAY = CloudServiceSettingsModel(TRANSITGATEWAYList[0].(map[string]interface{}))
 	}
+	var tRANSITGATEWAYATTACHMENT *models.CloudServiceSettings = nil
+	TRANSITGATEWAYATTACHMENTList := d["t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t"].([]interface{})
+	if len(TRANSITGATEWAYATTACHMENTList) > 0 { // len(nil) = 0
+		tRANSITGATEWAYATTACHMENT = CloudServiceSettingsModel(TRANSITGATEWAYATTACHMENTList[0].(map[string]interface{}))
+	}
 	var vIRTUALDESKTOP *models.CloudServiceSettings = nil
 	VIRTUALDESKTOPList := d["v_i_r_t_u_a_l_d_e_s_k_t_o_p"].([]interface{})
 	if len(VIRTUALDESKTOPList) > 0 { // len(nil) = 0
 		vIRTUALDESKTOP = CloudServiceSettingsModel(VIRTUALDESKTOPList[0].(map[string]interface{}))
+	}
+	var vIRTUALHUBS *models.CloudServiceSettings = nil
+	VIRTUALHUBSList := d["v_i_r_t_u_a_l_h_u_b_s"].([]interface{})
+	if len(VIRTUALHUBSList) > 0 { // len(nil) = 0
+		vIRTUALHUBS = CloudServiceSettingsModel(VIRTUALHUBSList[0].(map[string]interface{}))
 	}
 	var vIRTUALMACHINE *models.CloudServiceSettings = nil
 	VIRTUALMACHINEList := d["v_i_r_t_u_a_l_m_a_c_h_i_n_e"].([]interface{})
@@ -1421,10 +2209,20 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(VIRTUALNETWORKGATEWAYList) > 0 { // len(nil) = 0
 		vIRTUALNETWORKGATEWAY = CloudServiceSettingsModel(VIRTUALNETWORKGATEWAYList[0].(map[string]interface{}))
 	}
+	var vIRTUALNETWORKS *models.CloudServiceSettings = nil
+	VIRTUALNETWORKSList := d["v_i_r_t_u_a_l_n_e_t_w_o_r_k_s"].([]interface{})
+	if len(VIRTUALNETWORKSList) > 0 { // len(nil) = 0
+		vIRTUALNETWORKS = CloudServiceSettingsModel(VIRTUALNETWORKSList[0].(map[string]interface{}))
+	}
 	var vPN *models.CloudServiceSettings = nil
 	VPNList := d["v_p_n"].([]interface{})
 	if len(VPNList) > 0 { // len(nil) = 0
 		vPN = CloudServiceSettingsModel(VPNList[0].(map[string]interface{}))
+	}
+	var vPNGATEWAYS *models.CloudServiceSettings = nil
+	VPNGATEWAYSList := d["v_p_n_g_a_t_e_w_a_y_s"].([]interface{})
+	if len(VPNGATEWAYSList) > 0 { // len(nil) = 0
+		vPNGATEWAYS = CloudServiceSettingsModel(VPNGATEWAYSList[0].(map[string]interface{}))
 	}
 	var wORKSPACE *models.CloudServiceSettings = nil
 	WORKSPACEList := d["w_o_r_k_s_p_a_c_e"].([]interface{})
@@ -1436,144 +2234,225 @@ func CloudServicesModel(d map[string]interface{}) *models.CloudServices {
 	if len(WORKSPACEDIRECTORYList) > 0 { // len(nil) = 0
 		wORKSPACEDIRECTORY = CloudServiceSettingsModel(WORKSPACEDIRECTORYList[0].(map[string]interface{}))
 	}
-
-	return &models.CloudServices{
-		APIGATEWAY:               aPIGATEWAY,
-		APIMANAGEMENT:            aPIMANAGEMENT,
-		APPLICATIONELB:           aPPLICATIONELB,
-		APPLICATIONGATEWAY:       aPPLICATIONGATEWAY,
-		APPLICATIONINSIGHTS:      aPPLICATIONINSIGHTS,
-		APPSERVICE:               aPPSERVICE,
-		APPSERVICEPLAN:           aPPSERVICEPLAN,
-		APPSTREAM:                aPPSTREAM,
-		ATHENA:                   aTHENA,
-		AUTOMATIONACCOUNT:        aUTOMATIONACCOUNT,
-		AUTOSCALING:              aUTOSCALING,
-		BACKUPPROTECTEDITEMS:     bACKUPPROTECTEDITEMS,
-		BLOBSTORAGE:              bLOBSTORAGE,
-		CLOUDFRONT:               cLOUDFRONT,
-		CLOUDSEARCH:              cLOUDSEARCH,
-		CODEBUILD:                cODEBUILD,
-		COGNITIVESEARCH:          cOGNITIVESEARCH,
-		COGNITIVESERVICES:        cOGNITIVESERVICES,
-		COGNITO:                  cOGNITO,
-		COSMOSDB:                 cOSMOSDB,
-		DATAFACTORY:              dATAFACTORY,
-		DIRECTCONNECT:            dIRECTCONNECT,
-		DMSREPLICATION:           dMSREPLICATION,
-		DMSREPLICATIONTASKS:      dMSREPLICATIONTASKS,
-		DOCDB:                    dOCDB,
-		DYNAMODB:                 dYNAMODB,
-		EBS:                      eBS,
-		EC2:                      eC2,
-		ECS:                      eCS,
-		EFS:                      eFS,
-		ELASTICACHE:              eLASTICACHE,
-		ELASTICBEANSTALK:         eLASTICBEANSTALK,
-		ELASTICSEARCH:            eLASTICSEARCH,
-		ELASTICTRANSCODER:        eLASTICTRANSCODER,
-		ELB:                      eLB,
-		EMR:                      eMR,
-		EVENTBRIDGE:              eVENTBRIDGE,
-		EVENTHUB:                 eVENTHUB,
-		EXPRESSROUTECIRCUIT:      eXPRESSROUTECIRCUIT,
-		FILESTORAGE:              fILESTORAGE,
-		FIREHOSE:                 fIREHOSE,
-		FIREWALL:                 fIREWALL,
-		FRONTDOORS:               fRONTDOORS,
-		FSX:                      fSX,
-		GLUE:                     gLUE,
-		KEYVAULT:                 kEYVAULT,
-		KINESIS:                  kINESIS,
-		KINESISVIDEO:             kINESISVIDEO,
-		LAMBDA:                   lAMBDA,
-		LOADBALANCERS:            lOADBALANCERS,
-		LOGANALYTICSWORKSPACES:   lOGANALYTICSWORKSPACES,
-		LOGICAPPS:                lOGICAPPS,
-		MEDIACONNECT:             mEDIACONNECT,
-		MEDIACONVERT:             mEDIACONVERT,
-		MEDIAPACKAGELIVE:         mEDIAPACKAGELIVE,
-		MEDIAPACKAGEVOD:          mEDIAPACKAGEVOD,
-		MEDIASTORE:               mEDIASTORE,
-		MEDIATAILOR:              mEDIATAILOR,
-		MQ:                       mQ,
-		MSKBROKER:                mSKBROKER,
-		MSKCLUSTER:               mSKCLUSTER,
-		MYSQL:                    mYSQL,
-		NATGATEWAY:               nATGATEWAY,
-		NETWORKELB:               nETWORKELB,
-		NETWORKINTERFACE:         nETWORKINTERFACE,
-		OPSWORKS:                 oPSWORKS,
-		POSTGRESQL:               pOSTGRESQL,
-		PUBLICIP:                 pUBLICIP,
-		QUEUESTORAGE:             qUEUESTORAGE,
-		RDS:                      rDS,
-		RECOVERYPROTECTEDITEM:    rECOVERYPROTECTEDITEM,
-		RECOVERYSERVICES:         rECOVERYSERVICES,
-		REDISCACHE:               rEDISCACHE,
-		REDSHIFT:                 rEDSHIFT,
-		ROUTE53:                  rOUTE53,
-		ROUTE53RESOLVER:          rOUTE53RESOLVER,
-		S3:                       s3,
-		SAGEMAKER:                sAGEMAKER,
-		SERVICEBUS:               sERVICEBUS,
-		SES:                      sES,
-		SNS:                      sNS,
-		SQLDATABASE:              sQLDATABASE,
-		SQLELASTICPOOL:           sQLELASTICPOOL,
-		SQLMANAGEDINSTANCE:       sQLMANAGEDINSTANCE,
-		SQS:                      sQS,
-		STEPFUNCTIONS:            sTEPFUNCTIONS,
-		STORAGEACCOUNT:           sTORAGEACCOUNT,
-		SWFACTIVITY:              sWFACTIVITY,
-		SWFWORKFLOW:              sWFWORKFLOW,
-		SYNAPSEWORKSPACES:        sYNAPSEWORKSPACES,
-		TABLESTORAGE:             tABLESTORAGE,
-		TRAFFICMANAGER:           tRAFFICMANAGER,
-		TRANSITGATEWAY:           tRANSITGATEWAY,
-		VIRTUALDESKTOP:           vIRTUALDESKTOP,
-		VIRTUALMACHINE:           vIRTUALMACHINE,
-		VIRTUALMACHINESCALESET:   vIRTUALMACHINESCALESET,
+	
+	return &models.CloudServices {
+		ACM: aCM,
+		AKSMANAGEDCLUSTER: aKSMANAGEDCLUSTER,
+		ALARMS: aLARMS,
+		ANALYSISSERVICE: aNALYSISSERVICE,
+		APIGATEWAY: aPIGATEWAY,
+		APIGATEWAYV2: aPIGATEWAYV2,
+		APIMANAGEMENT: aPIMANAGEMENT,
+		APPLICATIONELB: aPPLICATIONELB,
+		APPLICATIONGATEWAY: aPPLICATIONGATEWAY,
+		APPLICATIONINSIGHTS: aPPLICATIONINSIGHTS,
+		APPLICATIONMIGRATIONSERVICE: aPPLICATIONMIGRATIONSERVICE,
+		APPSERVICE: aPPSERVICE,
+		APPSERVICEENVIRONMENT: aPPSERVICEENVIRONMENT,
+		APPSERVICEPLAN: aPPSERVICEPLAN,
+		APPSTREAM: aPPSTREAM,
+		ATHENA: aTHENA,
+		AUTOMATIONACCOUNT: aUTOMATIONACCOUNT,
+		AUTOSCALING: aUTOSCALING,
+		BACKUP: bACKUP,
+		BACKUPPROTECTEDITEMS: bACKUPPROTECTEDITEMS,
+		BACKUPPROTECTEDRESOURCE: bACKUPPROTECTEDRESOURCE,
+		BATCHACCOUNT: bATCHACCOUNT,
+		BEDROCK: bEDROCK,
+		BLOBSTORAGE: bLOBSTORAGE,
+		BOTSERVICES: bOTSERVICES,
+		CDNPROFILE: cDNPROFILE,
+		CLOUDFRONT: cLOUDFRONT,
+		CLOUDSEARCH: cLOUDSEARCH,
+		CODEBUILD: cODEBUILD,
+		COGNITIVESEARCH: cOGNITIVESEARCH,
+		COGNITIVESERVICES: cOGNITIVESERVICES,
+		COGNITO: cOGNITO,
+		CONTAINERAPPS: cONTAINERAPPS,
+		CONTAINERINSTANCE: cONTAINERINSTANCE,
+		CONTAINERREGISTRY: cONTAINERREGISTRY,
+		COSMOSDB: cOSMOSDB,
+		DATABRICKS: dATABRICKS,
+		DATAFACTORY: dATAFACTORY,
+		DATALAKEANALYTICS: dATALAKEANALYTICS,
+		DATALAKESTORE: dATALAKESTORE,
+		DBCLUSTER: dBCLUSTER,
+		DIRECTCONNECT: dIRECTCONNECT,
+		DIRECTCONNECTVIRTUALINTERFACE: dIRECTCONNECTVIRTUALINTERFACE,
+		DISKS: dISKS,
+		DMSREPLICATION: dMSREPLICATION,
+		DMSREPLICATIONTASKS: dMSREPLICATIONTASKS,
+		DOCDB: dOCDB,
+		DYNAMODB: dYNAMODB,
+		EBS: eBS,
+		EC2: eC2,
+		ECR: eCR,
+		ECS: eCS,
+		EFS: eFS,
+		EKS: eKS,
+		ELASTICACHE: eLASTICACHE,
+		ELASTICBEANSTALK: eLASTICBEANSTALK,
+		ELASTICSEARCH: eLASTICSEARCH,
+		ELASTICTRANSCODER: eLASTICTRANSCODER,
+		ELB: eLB,
+		EMR: eMR,
+		EVENTBRIDGE: eVENTBRIDGE,
+		EVENTGRID: eVENTGRID,
+		EVENTHUB: eVENTHUB,
+		EXPRESSROUTECIRCUIT: eXPRESSROUTECIRCUIT,
+		FILESTORAGE: fILESTORAGE,
+		FIREHOSE: fIREHOSE,
+		FIREWALL: fIREWALL,
+		FRONTDOORS: fRONTDOORS,
+		FSX: fSX,
+		FUNCTION: fUNCTION,
+		GATEWAYELB: gATEWAYELB,
+		GLOBALNETWORKS: gLOBALNETWORKS,
+		GLUE: gLUE,
+		HDINSIGHT: hDINSIGHT,
+		IOTHUB: iOTHUB,
+		KEYVAULT: kEYVAULT,
+		KINESIS: kINESIS,
+		KINESISVIDEO: kINESISVIDEO,
+		LAMBDA: lAMBDA,
+		LOADBALANCERS: lOADBALANCERS,
+		LOGANALYTICSWORKSPACES: lOGANALYTICSWORKSPACES,
+		LOGICAPPS: lOGICAPPS,
+		MARIADB: mARIADB,
+		MEDIACONNECT: mEDIACONNECT,
+		MEDIACONVERT: mEDIACONVERT,
+		MEDIAPACKAGELIVE: mEDIAPACKAGELIVE,
+		MEDIAPACKAGEVOD: mEDIAPACKAGEVOD,
+		MEDIASTORE: mEDIASTORE,
+		MEDIATAILOR: mEDIATAILOR,
+		MLWORKSPACES: mLWORKSPACES,
+		MQ: mQ,
+		MSKBROKER: mSKBROKER,
+		MSKCLUSTER: mSKCLUSTER,
+		MYSQL: mYSQL,
+		MYSQLFLEXIBLE: mYSQLFLEXIBLE,
+		NATGATEWAY: nATGATEWAY,
+		NATGATEWAYS: nATGATEWAYS,
+		NETAPPPOOLS: nETAPPPOOLS,
+		NETWORKELB: nETWORKELB,
+		NETWORKINTERFACE: nETWORKINTERFACE,
+		NOTIFICATIONHUBS: nOTIFICATIONHUBS,
+		OPENAISERVICES: oPENAISERVICES,
+		OPSWORKS: oPSWORKS,
+		POSTGRESQL: pOSTGRESQL,
+		POSTGRESQLCITUS: pOSTGRESQLCITUS,
+		POSTGRESQLFLEXIBLE: pOSTGRESQLFLEXIBLE,
+		POWERBIEMBEDDED: pOWERBIEMBEDDED,
+		PRIVATELINKENDPOINTS: pRIVATELINKENDPOINTS,
+		PRIVATELINKSERVICES: pRIVATELINKSERVICES,
+		PUBLICIP: pUBLICIP,
+		QBUSINESS: qBUSINESS,
+		QUEUESTORAGE: qUEUESTORAGE,
+		QUICKSIGHTDASHBOARDS: qUICKSIGHTDASHBOARDS,
+		QUICKSIGHTDATASETS: qUICKSIGHTDATASETS,
+		RDS: rDS,
+		RECOVERYPROTECTEDITEMS: rECOVERYPROTECTEDITEMS,
+		RECOVERYSERVICES: rECOVERYSERVICES,
+		REDISCACHE: rEDISCACHE,
+		REDISCACHEENTERPRISE: rEDISCACHEENTERPRISE,
+		REDSHIFT: rEDSHIFT,
+		REDSHIFTSERVERLESS: rEDSHIFTSERVERLESS,
+		RELAYNAMESPACES: rELAYNAMESPACES,
+		ROUTE53: rOUTE53,
+		ROUTE53HOSTEDZONE: rOUTE53HOSTEDZONE,
+		ROUTE53RESOLVER: rOUTE53RESOLVER,
+		S3: s3,
+		SAGEMAKER: sAGEMAKER,
+		SERVICEBUS: sERVICEBUS,
+		SERVICEFABRICMESH: sERVICEFABRICMESH,
+		SES: sES,
+		SIGNALR: sIGNALR,
+		SNS: sNS,
+		SQLDATABASE: sQLDATABASE,
+		SQLELASTICPOOL: sQLELASTICPOOL,
+		SQLMANAGEDINSTANCE: sQLMANAGEDINSTANCE,
+		SQS: sQS,
+		STEPFUNCTIONS: sTEPFUNCTIONS,
+		STORAGEACCOUNT: sTORAGEACCOUNT,
+		STREAMANALYTICS: sTREAMANALYTICS,
+		SWFACTIVITY: sWFACTIVITY,
+		SWFWORKFLOW: sWFWORKFLOW,
+		SYNAPSEWORKSPACES: sYNAPSEWORKSPACES,
+		TABLESTORAGE: tABLESTORAGE,
+		TRAFFICMANAGER: tRAFFICMANAGER,
+		TRANSFER: tRANSFER,
+		TRANSITGATEWAY: tRANSITGATEWAY,
+		TRANSITGATEWAYATTACHMENT: tRANSITGATEWAYATTACHMENT,
+		VIRTUALDESKTOP: vIRTUALDESKTOP,
+		VIRTUALHUBS: vIRTUALHUBS,
+		VIRTUALMACHINE: vIRTUALMACHINE,
+		VIRTUALMACHINESCALESET: vIRTUALMACHINESCALESET,
 		VIRTUALMACHINESCALESETVM: vIRTUALMACHINESCALESETVM,
-		VIRTUALNETWORKGATEWAY:    vIRTUALNETWORKGATEWAY,
-		VPN:                      vPN,
-		WORKSPACE:                wORKSPACE,
-		WORKSPACEDIRECTORY:       wORKSPACEDIRECTORY,
+		VIRTUALNETWORKGATEWAY: vIRTUALNETWORKGATEWAY,
+		VIRTUALNETWORKS: vIRTUALNETWORKS,
+		VPN: vPN,
+		VPNGATEWAYS: vPNGATEWAYS,
+		WORKSPACE: wORKSPACE,
+		WORKSPACEDIRECTORY: wORKSPACEDIRECTORY,
 	}
 }
 
 func GetCloudServicesPropertyFields() (t []string) {
 	return []string{
+		"a_c_m",
+		"a_k_s_m_a_n_a_g_e_d_c_l_u_s_t_e_r",
+		"a_l_a_r_m_s",
+		"a_n_a_l_y_s_i_s_s_e_r_v_i_c_e",
 		"api_g_a_t_e_w_a_y",
+		"api_g_a_t_e_w_a_y_v2",
 		"api_m_a_n_a_g_e_m_e_n_t",
 		"a_p_p_l_i_c_a_t_i_o_n_e_l_b",
 		"a_p_p_l_i_c_a_t_i_o_n_g_a_t_e_w_a_y",
 		"a_p_p_l_i_c_a_t_i_o_n_i_n_s_i_g_h_t_s",
+		"a_p_p_l_i_c_a_t_i_o_n_m_i_g_r_a_t_i_o_n_s_e_r_v_i_c_e",
 		"a_p_p_s_e_r_v_i_c_e",
+		"a_p_p_s_e_r_v_i_c_e_e_n_v_i_r_o_n_m_e_n_t",
 		"a_p_p_s_e_r_v_i_c_e_p_l_a_n",
 		"a_p_p_s_t_r_e_a_m",
 		"a_t_h_e_n_a",
 		"a_u_t_o_m_a_t_i_o_n_a_c_c_o_u_n_t",
 		"a_u_t_o_s_c_a_l_i_n_g",
+		"b_a_c_k_u_p",
 		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_i_t_e_m_s",
+		"b_a_c_k_u_p_p_r_o_t_e_c_t_e_d_r_e_s_o_u_r_c_e",
+		"b_a_t_c_h_a_c_c_o_u_n_t",
+		"b_e_d_r_o_c_k",
 		"b_l_o_b_s_t_o_r_a_g_e",
+		"b_o_t_s_e_r_v_i_c_e_s",
+		"c_d_n_p_r_o_f_i_l_e",
 		"c_l_o_u_d_f_r_o_n_t",
 		"c_l_o_u_d_s_e_a_r_c_h",
 		"c_o_d_e_b_ui_l_d",
 		"c_o_g_n_i_t_i_v_e_s_e_a_r_c_h",
 		"c_o_g_n_i_t_i_v_e_s_e_r_v_i_c_e_s",
 		"c_o_g_n_i_t_o",
+		"c_o_n_t_a_i_n_e_r_a_p_p_s",
+		"c_o_n_t_a_i_n_e_r_i_n_s_t_a_n_c_e",
+		"c_o_n_t_a_i_n_e_r_r_e_g_i_s_t_r_y",
 		"c_o_s_m_o_s_d_b",
+		"d_a_t_a_b_r_i_c_k_s",
 		"d_a_t_a_f_a_c_t_o_r_y",
+		"d_a_t_a_l_a_k_e_a_n_a_l_y_t_i_c_s",
+		"d_a_t_a_l_a_k_e_s_t_o_r_e",
+		"d_b_c_l_u_s_t_e_r",
 		"d_i_r_e_c_t_c_o_n_n_e_c_t",
+		"d_i_r_e_c_t_c_o_n_n_e_c_t_v_i_r_t_u_a_l_i_n_t_e_r_f_a_c_e",
+		"d_i_s_k_s",
 		"d_m_s_r_e_p_l_i_c_a_t_i_o_n",
 		"d_m_s_r_e_p_l_i_c_a_t_i_o_n_t_a_s_k_s",
 		"d_o_c_d_b",
 		"d_y_n_a_m_o_d_b",
 		"e_b_s",
 		"e_c2",
+		"e_c_r",
 		"e_c_s",
 		"e_f_s",
+		"e_k_s",
 		"e_l_a_s_t_i_c_a_c_h_e",
 		"e_l_a_s_t_i_c_b_e_a_n_s_t_a_l_k",
 		"e_l_a_s_t_i_c_s_e_a_r_c_h",
@@ -1581,6 +2460,7 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"e_l_b",
 		"e_m_r",
 		"e_v_e_n_t_b_r_id_g_e",
+		"e_v_e_n_t_g_r_id",
 		"e_v_e_n_t_h_u_b",
 		"e_x_p_r_e_s_s_r_o_u_t_e_c_i_r_c_ui_t",
 		"f_i_l_e_s_t_o_r_a_g_e",
@@ -1588,7 +2468,12 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"f_i_r_e_w_a_l_l",
 		"f_r_o_n_t_d_o_o_r_s",
 		"f_s_x",
+		"f_u_n_c_t_i_o_n",
+		"g_a_t_e_w_a_y_e_l_b",
+		"g_l_o_b_a_l_n_e_t_w_o_r_k_s",
 		"g_l_u_e",
+		"h_d_i_n_s_i_g_h_t",
+		"i_o_t_h_u_b",
 		"k_e_y_v_a_u_l_t",
 		"k_i_n_e_s_i_s",
 		"k_i_n_e_s_i_s_v_id_e_o",
@@ -1596,34 +2481,55 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"l_o_a_d_b_a_l_a_n_c_e_r_s",
 		"l_o_g_a_n_a_l_y_t_i_c_s_w_o_r_k_s_p_a_c_e_s",
 		"l_o_g_i_c_a_p_p_s",
+		"m_a_r_i_a_d_b",
 		"m_e_d_i_a_c_o_n_n_e_c_t",
 		"m_e_d_i_a_c_o_n_v_e_r_t",
 		"m_e_d_i_a_p_a_c_k_a_g_e_l_i_v_e",
 		"m_e_d_i_a_p_a_c_k_a_g_e_v_o_d",
 		"m_e_d_i_a_s_t_o_r_e",
 		"m_e_d_i_a_t_a_i_l_o_r",
+		"m_l_w_o_r_k_s_p_a_c_e_s",
 		"m_q",
 		"m_s_k_b_r_o_k_e_r",
 		"m_s_k_c_l_u_s_t_e_r",
 		"m_y_sql",
+		"m_y_sql_f_l_e_x_i_b_l_e",
 		"n_a_t_g_a_t_e_w_a_y",
+		"n_a_t_g_a_t_e_w_a_y_s",
+		"n_e_t_a_p_p_p_o_o_l_s",
 		"n_e_t_w_o_r_k_e_l_b",
 		"n_e_t_w_o_r_k_i_n_t_e_r_f_a_c_e",
+		"n_o_t_i_f_i_c_a_t_i_o_n_h_u_b_s",
+		"o_p_e_n_a_i_s_e_r_v_i_c_e_s",
 		"o_p_s_w_o_r_k_s",
 		"p_o_s_t_g_r_e_sql",
+		"p_o_s_t_g_r_e_sql_c_i_t_u_s",
+		"p_o_s_t_g_r_e_sql_f_l_e_x_i_b_l_e",
+		"p_o_w_e_r_b_i_e_m_b_e_d_d_e_d",
+		"p_r_i_v_a_t_e_l_i_n_k_e_n_d_p_o_i_n_t_s",
+		"p_r_i_v_a_t_e_l_i_n_k_s_e_r_v_i_c_e_s",
 		"p_u_b_l_i_c_ip",
+		"q_b_u_s_i_n_e_s_s",
 		"q_u_e_u_e_s_t_o_r_a_g_e",
+		"q_ui_c_k_s_i_g_h_t_d_a_s_h_b_o_a_r_d_s",
+		"q_ui_c_k_s_i_g_h_t_d_a_t_a_s_e_t_s",
 		"r_d_s",
-		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m",
+		"r_e_c_o_v_e_r_y_p_r_o_t_e_c_t_e_d_i_t_e_m_s",
 		"r_e_c_o_v_e_r_y_s_e_r_v_i_c_e_s",
 		"r_e_d_i_s_c_a_c_h_e",
+		"r_e_d_i_s_c_a_c_h_e_e_n_t_e_r_p_r_i_s_e",
 		"r_e_d_s_h_i_f_t",
+		"r_e_d_s_h_i_f_t_s_e_r_v_e_r_l_e_s_s",
+		"r_e_l_a_y_n_a_m_e_s_p_a_c_e_s",
 		"r_o_u_t_e53",
+		"r_o_u_t_e53_h_o_s_t_e_d_z_o_n_e",
 		"r_o_u_t_e53_r_e_s_o_l_v_e_r",
 		"s3",
 		"s_a_g_e_m_a_k_e_r",
 		"s_e_r_v_i_c_e_b_u_s",
+		"s_e_r_v_i_c_e_f_a_b_r_i_c_m_e_s_h",
 		"s_e_s",
+		"s_i_g_n_a_l_r",
 		"s_n_s",
 		"sql_d_a_t_a_b_a_s_e",
 		"sql_e_l_a_s_t_i_c_p_o_o_l",
@@ -1631,18 +2537,24 @@ func GetCloudServicesPropertyFields() (t []string) {
 		"s_q_s",
 		"s_t_e_p_f_u_n_c_t_i_o_n_s",
 		"s_t_o_r_a_g_e_a_c_c_o_u_n_t",
+		"s_t_r_e_a_m_a_n_a_l_y_t_i_c_s",
 		"s_w_f_a_c_t_i_v_i_t_y",
 		"s_w_f_w_o_r_k_f_l_o_w",
 		"s_y_n_a_p_s_e_w_o_r_k_s_p_a_c_e_s",
 		"t_a_b_l_e_s_t_o_r_a_g_e",
 		"t_r_a_f_f_i_c_m_a_n_a_g_e_r",
+		"t_r_a_n_s_f_e_r",
 		"t_r_a_n_s_i_t_g_a_t_e_w_a_y",
+		"t_r_a_n_s_i_t_g_a_t_e_w_a_y_a_t_t_a_c_h_m_e_n_t",
 		"v_i_r_t_u_a_l_d_e_s_k_t_o_p",
+		"v_i_r_t_u_a_l_h_u_b_s",
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e",
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t",
 		"v_i_r_t_u_a_l_m_a_c_h_i_n_e_s_c_a_l_e_s_e_t_vm",
 		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_g_a_t_e_w_a_y",
+		"v_i_r_t_u_a_l_n_e_t_w_o_r_k_s",
 		"v_p_n",
+		"v_p_n_g_a_t_e_w_a_y_s",
 		"w_o_r_k_s_p_a_c_e",
 		"w_o_r_k_s_p_a_c_e_d_i_r_e_c_t_o_r_y",
 	}

--- a/models/cloud_normal_collector_config.go
+++ b/models/cloud_normal_collector_config.go
@@ -25,7 +25,7 @@ type CloudNormalCollectorConfig struct {
 
 	// If the normal collector config is enabled
 	// Required: true
-	Enabled *bool `json:"enabled"`
+	Enable *bool `json:"enable"`
 }
 
 // Validate validates this cloud normal collector config
@@ -36,7 +36,7 @@ func (m *CloudNormalCollectorConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateEnabled(formats); err != nil {
+	if err := m.validateEnable(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -72,9 +72,9 @@ func (m *CloudNormalCollectorConfig) validateCollectors(formats strfmt.Registry)
 	return nil
 }
 
-func (m *CloudNormalCollectorConfig) validateEnabled(formats strfmt.Registry) error {
+func (m *CloudNormalCollectorConfig) validateEnable(formats strfmt.Registry) error {
 
-	if err := validate.Required("enabled", "body", m.Enabled); err != nil {
+	if err := validate.Required("enable", "body", m.Enable); err != nil {
 		return err
 	}
 

--- a/models/cloud_services.go
+++ b/models/cloud_services.go
@@ -18,8 +18,23 @@ import (
 // swagger:model CloudServices
 type CloudServices struct {
 
+	// ACM monitoring settings
+	ACM *CloudServiceSettings `json:"ACM,omitempty"`
+
+	// AKS Managed Cluster
+	AKSMANAGEDCLUSTER *CloudServiceSettings `json:"AKSMANAGEDCLUSTER,omitempty"`
+
+	// ALARMS monitoring settings
+	ALARMS *CloudServiceSettings `json:"ALARMS,omitempty"`
+
+	// Analysis Service
+	ANALYSISSERVICE *CloudServiceSettings `json:"ANALYSISSERVICE,omitempty"`
+
 	// APIGATEWAY monitoring settings
 	APIGATEWAY *CloudServiceSettings `json:"APIGATEWAY,omitempty"`
+
+	// APIGATEWAYV2 monitoring settings
+	APIGATEWAYV2 *CloudServiceSettings `json:"APIGATEWAYV2,omitempty"`
 
 	// API Management
 	APIMANAGEMENT *CloudServiceSettings `json:"APIMANAGEMENT,omitempty"`
@@ -33,8 +48,14 @@ type CloudServices struct {
 	// Application insights
 	APPLICATIONINSIGHTS *CloudServiceSettings `json:"APPLICATIONINSIGHTS,omitempty"`
 
+	// APPLICATIONMIGRATIONSERVICE monitoring settings
+	APPLICATIONMIGRATIONSERVICE *CloudServiceSettings `json:"APPLICATIONMIGRATIONSERVICE,omitempty"`
+
 	// App Service
 	APPSERVICE *CloudServiceSettings `json:"APPSERVICE,omitempty"`
+
+	// App Service Environment
+	APPSERVICEENVIRONMENT *CloudServiceSettings `json:"APPSERVICEENVIRONMENT,omitempty"`
 
 	// App Service plan
 	APPSERVICEPLAN *CloudServiceSettings `json:"APPSERVICEPLAN,omitempty"`
@@ -51,11 +72,29 @@ type CloudServices struct {
 	// AUTOSCALING monitoring settings
 	AUTOSCALING *CloudServiceSettings `json:"AUTOSCALING,omitempty"`
 
+	// BACKUP monitoring settings
+	BACKUP *CloudServiceSettings `json:"BACKUP,omitempty"`
+
 	// Backup protected items
 	BACKUPPROTECTEDITEMS *CloudServiceSettings `json:"BACKUPPROTECTEDITEMS,omitempty"`
 
+	// BACKUPPROTECTEDRESOURCE monitoring settings
+	BACKUPPROTECTEDRESOURCE *CloudServiceSettings `json:"BACKUPPROTECTEDRESOURCE,omitempty"`
+
+	// Batch Account
+	BATCHACCOUNT *CloudServiceSettings `json:"BATCHACCOUNT,omitempty"`
+
+	// BEDROCK monitoring settings
+	BEDROCK *CloudServiceSettings `json:"BEDROCK,omitempty"`
+
 	// Blob storage
 	BLOBSTORAGE *CloudServiceSettings `json:"BLOBSTORAGE,omitempty"`
+
+	// Bot Services
+	BOTSERVICES *CloudServiceSettings `json:"BOTSERVICES,omitempty"`
+
+	// CDN Profile
+	CDNPROFILE *CloudServiceSettings `json:"CDNPROFILE,omitempty"`
 
 	// CLOUDFRONT monitoring settings
 	CLOUDFRONT *CloudServiceSettings `json:"CLOUDFRONT,omitempty"`
@@ -75,14 +114,41 @@ type CloudServices struct {
 	// COGNITO monitoring settings
 	COGNITO *CloudServiceSettings `json:"COGNITO,omitempty"`
 
+	// Container Apps
+	CONTAINERAPPS *CloudServiceSettings `json:"CONTAINERAPPS,omitempty"`
+
+	// Container Instance
+	CONTAINERINSTANCE *CloudServiceSettings `json:"CONTAINERINSTANCE,omitempty"`
+
+	// Container Registry
+	CONTAINERREGISTRY *CloudServiceSettings `json:"CONTAINERREGISTRY,omitempty"`
+
 	// CosmosDB
 	COSMOSDB *CloudServiceSettings `json:"COSMOSDB,omitempty"`
+
+	// Databricks
+	DATABRICKS *CloudServiceSettings `json:"DATABRICKS,omitempty"`
 
 	// Data Factory
 	DATAFACTORY *CloudServiceSettings `json:"DATAFACTORY,omitempty"`
 
+	// Data Lake Analytics
+	DATALAKEANALYTICS *CloudServiceSettings `json:"DATALAKEANALYTICS,omitempty"`
+
+	// Data Lake Store
+	DATALAKESTORE *CloudServiceSettings `json:"DATALAKESTORE,omitempty"`
+
+	// DBCLUSTER monitoring settings
+	DBCLUSTER *CloudServiceSettings `json:"DBCLUSTER,omitempty"`
+
 	// DIRECTCONNECT monitoring settings
 	DIRECTCONNECT *CloudServiceSettings `json:"DIRECTCONNECT,omitempty"`
+
+	// DIRECTCONNECTVIRTUALINTERFACE monitoring settings
+	DIRECTCONNECTVIRTUALINTERFACE *CloudServiceSettings `json:"DIRECTCONNECTVIRTUALINTERFACE,omitempty"`
+
+	// Disks
+	DISKS *CloudServiceSettings `json:"DISKS,omitempty"`
 
 	// DMSREPLICATION monitoring settings
 	DMSREPLICATION *CloudServiceSettings `json:"DMSREPLICATION,omitempty"`
@@ -102,11 +168,17 @@ type CloudServices struct {
 	// EC2 monitoring settings
 	EC2 *CloudServiceSettings `json:"EC2,omitempty"`
 
+	// ECR monitoring settings
+	ECR *CloudServiceSettings `json:"ECR,omitempty"`
+
 	// ECS monitoring settings
 	ECS *CloudServiceSettings `json:"ECS,omitempty"`
 
 	// EFS monitoring settings
 	EFS *CloudServiceSettings `json:"EFS,omitempty"`
+
+	// EKS monitoring settings
+	EKS *CloudServiceSettings `json:"EKS,omitempty"`
 
 	// ELASTICACHE monitoring settings
 	ELASTICACHE *CloudServiceSettings `json:"ELASTICACHE,omitempty"`
@@ -129,6 +201,9 @@ type CloudServices struct {
 	// EVENTBRIDGE monitoring settings
 	EVENTBRIDGE *CloudServiceSettings `json:"EVENTBRIDGE,omitempty"`
 
+	// Event Grid
+	EVENTGRID *CloudServiceSettings `json:"EVENTGRID,omitempty"`
+
 	// Event Hub
 	EVENTHUB *CloudServiceSettings `json:"EVENTHUB,omitempty"`
 
@@ -150,8 +225,23 @@ type CloudServices struct {
 	// FSX monitoring settings
 	FSX *CloudServiceSettings `json:"FSX,omitempty"`
 
+	// FUNCTION
+	FUNCTION *CloudServiceSettings `json:"FUNCTION,omitempty"`
+
+	// GATEWAYELB monitoring settings
+	GATEWAYELB *CloudServiceSettings `json:"GATEWAYELB,omitempty"`
+
+	// GLOBALNETWORKS monitoring settings
+	GLOBALNETWORKS *CloudServiceSettings `json:"GLOBALNETWORKS,omitempty"`
+
 	// GLUE monitoring settings
 	GLUE *CloudServiceSettings `json:"GLUE,omitempty"`
+
+	// HDInsight
+	HDINSIGHT *CloudServiceSettings `json:"HDINSIGHT,omitempty"`
+
+	// IoT Hub
+	IOTHUB *CloudServiceSettings `json:"IOTHUB,omitempty"`
 
 	// Key vault
 	KEYVAULT *CloudServiceSettings `json:"KEYVAULT,omitempty"`
@@ -174,6 +264,9 @@ type CloudServices struct {
 	// Logic Apps
 	LOGICAPPS *CloudServiceSettings `json:"LOGICAPPS,omitempty"`
 
+	// MariaDB
+	MARIADB *CloudServiceSettings `json:"MARIADB,omitempty"`
+
 	// MEDIACONNECT monitoring settings
 	MEDIACONNECT *CloudServiceSettings `json:"MEDIACONNECT,omitempty"`
 
@@ -192,6 +285,9 @@ type CloudServices struct {
 	// MEDIATAILOR monitoring settings
 	MEDIATAILOR *CloudServiceSettings `json:"MEDIATAILOR,omitempty"`
 
+	// Machine Learning Workspaces
+	MLWORKSPACES *CloudServiceSettings `json:"MLWORKSPACES,omitempty"`
+
 	// MQ monitoring settings
 	MQ *CloudServiceSettings `json:"MQ,omitempty"`
 
@@ -204,8 +300,17 @@ type CloudServices struct {
 	// My sql
 	MYSQL *CloudServiceSettings `json:"MYSQL,omitempty"`
 
+	// MySQL Flexible
+	MYSQLFLEXIBLE *CloudServiceSettings `json:"MYSQLFLEXIBLE,omitempty"`
+
 	// NATGATEWAY monitoring settings
 	NATGATEWAY *CloudServiceSettings `json:"NATGATEWAY,omitempty"`
+
+	// NAT Gateways
+	NATGATEWAYS *CloudServiceSettings `json:"NATGATEWAYS,omitempty"`
+
+	// NetApp Pools
+	NETAPPPOOLS *CloudServiceSettings `json:"NETAPPPOOLS,omitempty"`
 
 	// NETWORKELB monitoring settings
 	NETWORKELB *CloudServiceSettings `json:"NETWORKELB,omitempty"`
@@ -213,23 +318,53 @@ type CloudServices struct {
 	// Network interface
 	NETWORKINTERFACE *CloudServiceSettings `json:"NETWORKINTERFACE,omitempty"`
 
+	// Notification Hubs
+	NOTIFICATIONHUBS *CloudServiceSettings `json:"NOTIFICATIONHUBS,omitempty"`
+
+	// OpenAI Services
+	OPENAISERVICES *CloudServiceSettings `json:"OPENAISERVICES,omitempty"`
+
 	// OPSWORKS monitoring settings
 	OPSWORKS *CloudServiceSettings `json:"OPSWORKS,omitempty"`
 
 	// PostgreSQL
 	POSTGRESQL *CloudServiceSettings `json:"POSTGRESQL,omitempty"`
 
+	// PostgreSQL Citus
+	POSTGRESQLCITUS *CloudServiceSettings `json:"POSTGRESQLCITUS,omitempty"`
+
+	// PostgreSQL Flexible
+	POSTGRESQLFLEXIBLE *CloudServiceSettings `json:"POSTGRESQLFLEXIBLE,omitempty"`
+
+	// Power BI Embedded
+	POWERBIEMBEDDED *CloudServiceSettings `json:"POWERBIEMBEDDED,omitempty"`
+
+	// PRIVATELINKENDPOINTS monitoring settings
+	PRIVATELINKENDPOINTS *CloudServiceSettings `json:"PRIVATELINKENDPOINTS,omitempty"`
+
+	// PRIVATELINKSERVICES monitoring settings
+	PRIVATELINKSERVICES *CloudServiceSettings `json:"PRIVATELINKSERVICES,omitempty"`
+
 	// Public IP
 	PUBLICIP *CloudServiceSettings `json:"PUBLICIP,omitempty"`
+
+	// QBUSINESS monitoring settings
+	QBUSINESS *CloudServiceSettings `json:"QBUSINESS,omitempty"`
 
 	// Queue storage
 	QUEUESTORAGE *CloudServiceSettings `json:"QUEUESTORAGE,omitempty"`
 
+	// QUICKSIGHTDASHBOARDS monitoring settings
+	QUICKSIGHTDASHBOARDS *CloudServiceSettings `json:"QUICKSIGHTDASHBOARDS,omitempty"`
+
+	// QUICKSIGHTDATASETS monitoring settings
+	QUICKSIGHTDATASETS *CloudServiceSettings `json:"QUICKSIGHTDATASETS,omitempty"`
+
 	// RDS monitoring settings
 	RDS *CloudServiceSettings `json:"RDS,omitempty"`
 
-	// Recovery Protected Item
-	RECOVERYPROTECTEDITEM *CloudServiceSettings `json:"RECOVERYPROTECTEDITEM,omitempty"`
+	// Recovery Protected Items
+	RECOVERYPROTECTEDITEMS *CloudServiceSettings `json:"RECOVERYPROTECTEDITEMS,omitempty"`
 
 	// Recovery Services
 	RECOVERYSERVICES *CloudServiceSettings `json:"RECOVERYSERVICES,omitempty"`
@@ -237,11 +372,23 @@ type CloudServices struct {
 	// Redis Cache
 	REDISCACHE *CloudServiceSettings `json:"REDISCACHE,omitempty"`
 
+	// Redis Cache Enterprise
+	REDISCACHEENTERPRISE *CloudServiceSettings `json:"REDISCACHEENTERPRISE,omitempty"`
+
 	// REDSHIFT monitoring settings
 	REDSHIFT *CloudServiceSettings `json:"REDSHIFT,omitempty"`
 
+	// REDSHIFTSERVERLESS monitoring settings
+	REDSHIFTSERVERLESS *CloudServiceSettings `json:"REDSHIFTSERVERLESS,omitempty"`
+
+	// Relay Namespaces
+	RELAYNAMESPACES *CloudServiceSettings `json:"RELAYNAMESPACES,omitempty"`
+
 	// ROUTE53 monitoring settings
 	ROUTE53 *CloudServiceSettings `json:"ROUTE53,omitempty"`
+
+	// ROUTE53HOSTEDZONE monitoring settings
+	ROUTE53HOSTEDZONE *CloudServiceSettings `json:"ROUTE53HOSTEDZONE,omitempty"`
 
 	// ROUTE53RESOLVER monitoring settings
 	ROUTE53RESOLVER *CloudServiceSettings `json:"ROUTE53RESOLVER,omitempty"`
@@ -255,8 +402,14 @@ type CloudServices struct {
 	// Service Bus
 	SERVICEBUS *CloudServiceSettings `json:"SERVICEBUS,omitempty"`
 
+	// Service Fabric Mesh
+	SERVICEFABRICMESH *CloudServiceSettings `json:"SERVICEFABRICMESH,omitempty"`
+
 	// SES monitoring settings
 	SES *CloudServiceSettings `json:"SES,omitempty"`
+
+	// SignalR
+	SIGNALR *CloudServiceSettings `json:"SIGNALR,omitempty"`
 
 	// SNS monitoring settings
 	SNS *CloudServiceSettings `json:"SNS,omitempty"`
@@ -279,6 +432,9 @@ type CloudServices struct {
 	// Storage account
 	STORAGEACCOUNT *CloudServiceSettings `json:"STORAGEACCOUNT,omitempty"`
 
+	// Stream Analytics
+	STREAMANALYTICS *CloudServiceSettings `json:"STREAMANALYTICS,omitempty"`
+
 	// SWFACTIVITY monitoring settings
 	SWFACTIVITY *CloudServiceSettings `json:"SWFACTIVITY,omitempty"`
 
@@ -294,11 +450,20 @@ type CloudServices struct {
 	// TRAFFICMANAGER
 	TRAFFICMANAGER *CloudServiceSettings `json:"TRAFFICMANAGER,omitempty"`
 
+	// TRANSFER monitoring settings
+	TRANSFER *CloudServiceSettings `json:"TRANSFER,omitempty"`
+
 	// TRANSITGATEWAY monitoring settings
 	TRANSITGATEWAY *CloudServiceSettings `json:"TRANSITGATEWAY,omitempty"`
 
+	// TRANSITGATEWAYATTACHMENT monitoring settings
+	TRANSITGATEWAYATTACHMENT *CloudServiceSettings `json:"TRANSITGATEWAYATTACHMENT,omitempty"`
+
 	// Virtual Desktop
 	VIRTUALDESKTOP *CloudServiceSettings `json:"VIRTUALDESKTOP,omitempty"`
+
+	// Virtual Hubs
+	VIRTUALHUBS *CloudServiceSettings `json:"VIRTUALHUBS,omitempty"`
 
 	// VIRTUAL machine
 	VIRTUALMACHINE *CloudServiceSettings `json:"VIRTUALMACHINE,omitempty"`
@@ -312,8 +477,14 @@ type CloudServices struct {
 	// Virtual Network Gateway
 	VIRTUALNETWORKGATEWAY *CloudServiceSettings `json:"VIRTUALNETWORKGATEWAY,omitempty"`
 
+	// Virtual Networks
+	VIRTUALNETWORKS *CloudServiceSettings `json:"VIRTUALNETWORKS,omitempty"`
+
 	// VPN monitoring settings
 	VPN *CloudServiceSettings `json:"VPN,omitempty"`
+
+	// VPN Gateways
+	VPNGATEWAYS *CloudServiceSettings `json:"VPNGATEWAYS,omitempty"`
 
 	// WORKSPACE monitoring settings
 	WORKSPACE *CloudServiceSettings `json:"WORKSPACE,omitempty"`
@@ -326,7 +497,27 @@ type CloudServices struct {
 func (m *CloudServices) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateACM(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateAKSMANAGEDCLUSTER(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateALARMS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateANALYSISSERVICE(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateAPIGATEWAY(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateAPIGATEWAYV2(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -346,7 +537,15 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateAPPLICATIONMIGRATIONSERVICE(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateAPPSERVICE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateAPPSERVICEENVIRONMENT(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -370,11 +569,35 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateBACKUP(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateBACKUPPROTECTEDITEMS(formats); err != nil {
 		res = append(res, err)
 	}
 
+	if err := m.validateBACKUPPROTECTEDRESOURCE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateBATCHACCOUNT(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateBEDROCK(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateBLOBSTORAGE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateBOTSERVICES(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCDNPROFILE(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -402,7 +625,23 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCONTAINERAPPS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCONTAINERINSTANCE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCONTAINERREGISTRY(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateCOSMOSDB(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDATABRICKS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -410,7 +649,27 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateDATALAKEANALYTICS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDATALAKESTORE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDBCLUSTER(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateDIRECTCONNECT(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDIRECTCONNECTVIRTUALINTERFACE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDISKS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -438,11 +697,19 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateECR(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateECS(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateEFS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateEKS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -474,6 +741,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateEVENTGRID(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateEVENTHUB(formats); err != nil {
 		res = append(res, err)
 	}
@@ -502,7 +773,27 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateFUNCTION(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateGATEWAYELB(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateGLOBALNETWORKS(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateGLUE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateHDINSIGHT(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIOTHUB(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -534,6 +825,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateMARIADB(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateMEDIACONNECT(formats); err != nil {
 		res = append(res, err)
 	}
@@ -558,6 +853,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateMLWORKSPACES(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateMQ(formats); err != nil {
 		res = append(res, err)
 	}
@@ -574,7 +873,19 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateMYSQLFLEXIBLE(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateNATGATEWAY(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateNATGATEWAYS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateNETAPPPOOLS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -586,6 +897,14 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateNOTIFICATIONHUBS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateOPENAISERVICES(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateOPSWORKS(formats); err != nil {
 		res = append(res, err)
 	}
@@ -594,7 +913,31 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validatePOSTGRESQLCITUS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePOSTGRESQLFLEXIBLE(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePOWERBIEMBEDDED(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePRIVATELINKENDPOINTS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePRIVATELINKSERVICES(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validatePUBLICIP(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateQBUSINESS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -602,11 +945,19 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateQUICKSIGHTDASHBOARDS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateQUICKSIGHTDATASETS(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateRDS(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateRECOVERYPROTECTEDITEM(formats); err != nil {
+	if err := m.validateRECOVERYPROTECTEDITEMS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -618,11 +969,27 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateREDISCACHEENTERPRISE(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateREDSHIFT(formats); err != nil {
 		res = append(res, err)
 	}
 
+	if err := m.validateREDSHIFTSERVERLESS(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRELAYNAMESPACES(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateROUTE53(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateROUTE53HOSTEDZONE(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -642,7 +1009,15 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateSERVICEFABRICMESH(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSES(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSIGNALR(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -674,6 +1049,10 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateSTREAMANALYTICS(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSWFACTIVITY(formats); err != nil {
 		res = append(res, err)
 	}
@@ -694,11 +1073,23 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateTRANSFER(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateTRANSITGATEWAY(formats); err != nil {
 		res = append(res, err)
 	}
 
+	if err := m.validateTRANSITGATEWAYATTACHMENT(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateVIRTUALDESKTOP(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateVIRTUALHUBS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -718,7 +1109,15 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateVIRTUALNETWORKS(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateVPN(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateVPNGATEWAYS(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -736,6 +1135,82 @@ func (m *CloudServices) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateACM(formats strfmt.Registry) error {
+	if swag.IsZero(m.ACM) { // not required
+		return nil
+	}
+
+	if m.ACM != nil {
+		if err := m.ACM.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ACM")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ACM")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateAKSMANAGEDCLUSTER(formats strfmt.Registry) error {
+	if swag.IsZero(m.AKSMANAGEDCLUSTER) { // not required
+		return nil
+	}
+
+	if m.AKSMANAGEDCLUSTER != nil {
+		if err := m.AKSMANAGEDCLUSTER.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("AKSMANAGEDCLUSTER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("AKSMANAGEDCLUSTER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateALARMS(formats strfmt.Registry) error {
+	if swag.IsZero(m.ALARMS) { // not required
+		return nil
+	}
+
+	if m.ALARMS != nil {
+		if err := m.ALARMS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ALARMS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ALARMS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateANALYSISSERVICE(formats strfmt.Registry) error {
+	if swag.IsZero(m.ANALYSISSERVICE) { // not required
+		return nil
+	}
+
+	if m.ANALYSISSERVICE != nil {
+		if err := m.ANALYSISSERVICE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ANALYSISSERVICE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ANALYSISSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateAPIGATEWAY(formats strfmt.Registry) error {
 	if swag.IsZero(m.APIGATEWAY) { // not required
 		return nil
@@ -747,6 +1222,25 @@ func (m *CloudServices) validateAPIGATEWAY(formats strfmt.Registry) error {
 				return ve.ValidateName("APIGATEWAY")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("APIGATEWAY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateAPIGATEWAYV2(formats strfmt.Registry) error {
+	if swag.IsZero(m.APIGATEWAYV2) { // not required
+		return nil
+	}
+
+	if m.APIGATEWAYV2 != nil {
+		if err := m.APIGATEWAYV2.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APIGATEWAYV2")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APIGATEWAYV2")
 			}
 			return err
 		}
@@ -831,6 +1325,25 @@ func (m *CloudServices) validateAPPLICATIONINSIGHTS(formats strfmt.Registry) err
 	return nil
 }
 
+func (m *CloudServices) validateAPPLICATIONMIGRATIONSERVICE(formats strfmt.Registry) error {
+	if swag.IsZero(m.APPLICATIONMIGRATIONSERVICE) { // not required
+		return nil
+	}
+
+	if m.APPLICATIONMIGRATIONSERVICE != nil {
+		if err := m.APPLICATIONMIGRATIONSERVICE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateAPPSERVICE(formats strfmt.Registry) error {
 	if swag.IsZero(m.APPSERVICE) { // not required
 		return nil
@@ -842,6 +1355,25 @@ func (m *CloudServices) validateAPPSERVICE(formats strfmt.Registry) error {
 				return ve.ValidateName("APPSERVICE")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("APPSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateAPPSERVICEENVIRONMENT(formats strfmt.Registry) error {
+	if swag.IsZero(m.APPSERVICEENVIRONMENT) { // not required
+		return nil
+	}
+
+	if m.APPSERVICEENVIRONMENT != nil {
+		if err := m.APPSERVICEENVIRONMENT.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APPSERVICEENVIRONMENT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APPSERVICEENVIRONMENT")
 			}
 			return err
 		}
@@ -945,6 +1477,25 @@ func (m *CloudServices) validateAUTOSCALING(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateBACKUP(formats strfmt.Registry) error {
+	if swag.IsZero(m.BACKUP) { // not required
+		return nil
+	}
+
+	if m.BACKUP != nil {
+		if err := m.BACKUP.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUP")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateBACKUPPROTECTEDITEMS(formats strfmt.Registry) error {
 	if swag.IsZero(m.BACKUPPROTECTEDITEMS) { // not required
 		return nil
@@ -964,6 +1515,63 @@ func (m *CloudServices) validateBACKUPPROTECTEDITEMS(formats strfmt.Registry) er
 	return nil
 }
 
+func (m *CloudServices) validateBACKUPPROTECTEDRESOURCE(formats strfmt.Registry) error {
+	if swag.IsZero(m.BACKUPPROTECTEDRESOURCE) { // not required
+		return nil
+	}
+
+	if m.BACKUPPROTECTEDRESOURCE != nil {
+		if err := m.BACKUPPROTECTEDRESOURCE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUPPROTECTEDRESOURCE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUPPROTECTEDRESOURCE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateBATCHACCOUNT(formats strfmt.Registry) error {
+	if swag.IsZero(m.BATCHACCOUNT) { // not required
+		return nil
+	}
+
+	if m.BATCHACCOUNT != nil {
+		if err := m.BATCHACCOUNT.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BATCHACCOUNT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BATCHACCOUNT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateBEDROCK(formats strfmt.Registry) error {
+	if swag.IsZero(m.BEDROCK) { // not required
+		return nil
+	}
+
+	if m.BEDROCK != nil {
+		if err := m.BEDROCK.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BEDROCK")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BEDROCK")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateBLOBSTORAGE(formats strfmt.Registry) error {
 	if swag.IsZero(m.BLOBSTORAGE) { // not required
 		return nil
@@ -975,6 +1583,44 @@ func (m *CloudServices) validateBLOBSTORAGE(formats strfmt.Registry) error {
 				return ve.ValidateName("BLOBSTORAGE")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("BLOBSTORAGE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateBOTSERVICES(formats strfmt.Registry) error {
+	if swag.IsZero(m.BOTSERVICES) { // not required
+		return nil
+	}
+
+	if m.BOTSERVICES != nil {
+		if err := m.BOTSERVICES.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BOTSERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BOTSERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateCDNPROFILE(formats strfmt.Registry) error {
+	if swag.IsZero(m.CDNPROFILE) { // not required
+		return nil
+	}
+
+	if m.CDNPROFILE != nil {
+		if err := m.CDNPROFILE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CDNPROFILE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CDNPROFILE")
 			}
 			return err
 		}
@@ -1097,6 +1743,63 @@ func (m *CloudServices) validateCOGNITO(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateCONTAINERAPPS(formats strfmt.Registry) error {
+	if swag.IsZero(m.CONTAINERAPPS) { // not required
+		return nil
+	}
+
+	if m.CONTAINERAPPS != nil {
+		if err := m.CONTAINERAPPS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CONTAINERAPPS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CONTAINERAPPS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateCONTAINERINSTANCE(formats strfmt.Registry) error {
+	if swag.IsZero(m.CONTAINERINSTANCE) { // not required
+		return nil
+	}
+
+	if m.CONTAINERINSTANCE != nil {
+		if err := m.CONTAINERINSTANCE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CONTAINERINSTANCE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CONTAINERINSTANCE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateCONTAINERREGISTRY(formats strfmt.Registry) error {
+	if swag.IsZero(m.CONTAINERREGISTRY) { // not required
+		return nil
+	}
+
+	if m.CONTAINERREGISTRY != nil {
+		if err := m.CONTAINERREGISTRY.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CONTAINERREGISTRY")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CONTAINERREGISTRY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateCOSMOSDB(formats strfmt.Registry) error {
 	if swag.IsZero(m.COSMOSDB) { // not required
 		return nil
@@ -1108,6 +1811,25 @@ func (m *CloudServices) validateCOSMOSDB(formats strfmt.Registry) error {
 				return ve.ValidateName("COSMOSDB")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("COSMOSDB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDATABRICKS(formats strfmt.Registry) error {
+	if swag.IsZero(m.DATABRICKS) { // not required
+		return nil
+	}
+
+	if m.DATABRICKS != nil {
+		if err := m.DATABRICKS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DATABRICKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DATABRICKS")
 			}
 			return err
 		}
@@ -1135,6 +1857,63 @@ func (m *CloudServices) validateDATAFACTORY(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateDATALAKEANALYTICS(formats strfmt.Registry) error {
+	if swag.IsZero(m.DATALAKEANALYTICS) { // not required
+		return nil
+	}
+
+	if m.DATALAKEANALYTICS != nil {
+		if err := m.DATALAKEANALYTICS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DATALAKEANALYTICS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DATALAKEANALYTICS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDATALAKESTORE(formats strfmt.Registry) error {
+	if swag.IsZero(m.DATALAKESTORE) { // not required
+		return nil
+	}
+
+	if m.DATALAKESTORE != nil {
+		if err := m.DATALAKESTORE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DATALAKESTORE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DATALAKESTORE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDBCLUSTER(formats strfmt.Registry) error {
+	if swag.IsZero(m.DBCLUSTER) { // not required
+		return nil
+	}
+
+	if m.DBCLUSTER != nil {
+		if err := m.DBCLUSTER.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DBCLUSTER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DBCLUSTER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateDIRECTCONNECT(formats strfmt.Registry) error {
 	if swag.IsZero(m.DIRECTCONNECT) { // not required
 		return nil
@@ -1146,6 +1925,44 @@ func (m *CloudServices) validateDIRECTCONNECT(formats strfmt.Registry) error {
 				return ve.ValidateName("DIRECTCONNECT")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("DIRECTCONNECT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDIRECTCONNECTVIRTUALINTERFACE(formats strfmt.Registry) error {
+	if swag.IsZero(m.DIRECTCONNECTVIRTUALINTERFACE) { // not required
+		return nil
+	}
+
+	if m.DIRECTCONNECTVIRTUALINTERFACE != nil {
+		if err := m.DIRECTCONNECTVIRTUALINTERFACE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateDISKS(formats strfmt.Registry) error {
+	if swag.IsZero(m.DISKS) { // not required
+		return nil
+	}
+
+	if m.DISKS != nil {
+		if err := m.DISKS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DISKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DISKS")
 			}
 			return err
 		}
@@ -1268,6 +2085,25 @@ func (m *CloudServices) validateEC2(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateECR(formats strfmt.Registry) error {
+	if swag.IsZero(m.ECR) { // not required
+		return nil
+	}
+
+	if m.ECR != nil {
+		if err := m.ECR.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ECR")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ECR")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateECS(formats strfmt.Registry) error {
 	if swag.IsZero(m.ECS) { // not required
 		return nil
@@ -1298,6 +2134,25 @@ func (m *CloudServices) validateEFS(formats strfmt.Registry) error {
 				return ve.ValidateName("EFS")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("EFS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateEKS(formats strfmt.Registry) error {
+	if swag.IsZero(m.EKS) { // not required
+		return nil
+	}
+
+	if m.EKS != nil {
+		if err := m.EKS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("EKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("EKS")
 			}
 			return err
 		}
@@ -1439,6 +2294,25 @@ func (m *CloudServices) validateEVENTBRIDGE(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateEVENTGRID(formats strfmt.Registry) error {
+	if swag.IsZero(m.EVENTGRID) { // not required
+		return nil
+	}
+
+	if m.EVENTGRID != nil {
+		if err := m.EVENTGRID.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("EVENTGRID")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("EVENTGRID")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateEVENTHUB(formats strfmt.Registry) error {
 	if swag.IsZero(m.EVENTHUB) { // not required
 		return nil
@@ -1572,6 +2446,63 @@ func (m *CloudServices) validateFSX(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateFUNCTION(formats strfmt.Registry) error {
+	if swag.IsZero(m.FUNCTION) { // not required
+		return nil
+	}
+
+	if m.FUNCTION != nil {
+		if err := m.FUNCTION.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("FUNCTION")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("FUNCTION")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateGATEWAYELB(formats strfmt.Registry) error {
+	if swag.IsZero(m.GATEWAYELB) { // not required
+		return nil
+	}
+
+	if m.GATEWAYELB != nil {
+		if err := m.GATEWAYELB.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("GATEWAYELB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("GATEWAYELB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateGLOBALNETWORKS(formats strfmt.Registry) error {
+	if swag.IsZero(m.GLOBALNETWORKS) { // not required
+		return nil
+	}
+
+	if m.GLOBALNETWORKS != nil {
+		if err := m.GLOBALNETWORKS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("GLOBALNETWORKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("GLOBALNETWORKS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateGLUE(formats strfmt.Registry) error {
 	if swag.IsZero(m.GLUE) { // not required
 		return nil
@@ -1583,6 +2514,44 @@ func (m *CloudServices) validateGLUE(formats strfmt.Registry) error {
 				return ve.ValidateName("GLUE")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("GLUE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateHDINSIGHT(formats strfmt.Registry) error {
+	if swag.IsZero(m.HDINSIGHT) { // not required
+		return nil
+	}
+
+	if m.HDINSIGHT != nil {
+		if err := m.HDINSIGHT.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("HDINSIGHT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("HDINSIGHT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateIOTHUB(formats strfmt.Registry) error {
+	if swag.IsZero(m.IOTHUB) { // not required
+		return nil
+	}
+
+	if m.IOTHUB != nil {
+		if err := m.IOTHUB.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("IOTHUB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("IOTHUB")
 			}
 			return err
 		}
@@ -1724,6 +2693,25 @@ func (m *CloudServices) validateLOGICAPPS(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateMARIADB(formats strfmt.Registry) error {
+	if swag.IsZero(m.MARIADB) { // not required
+		return nil
+	}
+
+	if m.MARIADB != nil {
+		if err := m.MARIADB.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("MARIADB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("MARIADB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateMEDIACONNECT(formats strfmt.Registry) error {
 	if swag.IsZero(m.MEDIACONNECT) { // not required
 		return nil
@@ -1838,6 +2826,25 @@ func (m *CloudServices) validateMEDIATAILOR(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateMLWORKSPACES(formats strfmt.Registry) error {
+	if swag.IsZero(m.MLWORKSPACES) { // not required
+		return nil
+	}
+
+	if m.MLWORKSPACES != nil {
+		if err := m.MLWORKSPACES.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("MLWORKSPACES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("MLWORKSPACES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateMQ(formats strfmt.Registry) error {
 	if swag.IsZero(m.MQ) { // not required
 		return nil
@@ -1914,6 +2921,25 @@ func (m *CloudServices) validateMYSQL(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateMYSQLFLEXIBLE(formats strfmt.Registry) error {
+	if swag.IsZero(m.MYSQLFLEXIBLE) { // not required
+		return nil
+	}
+
+	if m.MYSQLFLEXIBLE != nil {
+		if err := m.MYSQLFLEXIBLE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("MYSQLFLEXIBLE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("MYSQLFLEXIBLE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateNATGATEWAY(formats strfmt.Registry) error {
 	if swag.IsZero(m.NATGATEWAY) { // not required
 		return nil
@@ -1925,6 +2951,44 @@ func (m *CloudServices) validateNATGATEWAY(formats strfmt.Registry) error {
 				return ve.ValidateName("NATGATEWAY")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("NATGATEWAY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateNATGATEWAYS(formats strfmt.Registry) error {
+	if swag.IsZero(m.NATGATEWAYS) { // not required
+		return nil
+	}
+
+	if m.NATGATEWAYS != nil {
+		if err := m.NATGATEWAYS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("NATGATEWAYS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("NATGATEWAYS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateNETAPPPOOLS(formats strfmt.Registry) error {
+	if swag.IsZero(m.NETAPPPOOLS) { // not required
+		return nil
+	}
+
+	if m.NETAPPPOOLS != nil {
+		if err := m.NETAPPPOOLS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("NETAPPPOOLS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("NETAPPPOOLS")
 			}
 			return err
 		}
@@ -1971,6 +3035,44 @@ func (m *CloudServices) validateNETWORKINTERFACE(formats strfmt.Registry) error 
 	return nil
 }
 
+func (m *CloudServices) validateNOTIFICATIONHUBS(formats strfmt.Registry) error {
+	if swag.IsZero(m.NOTIFICATIONHUBS) { // not required
+		return nil
+	}
+
+	if m.NOTIFICATIONHUBS != nil {
+		if err := m.NOTIFICATIONHUBS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("NOTIFICATIONHUBS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("NOTIFICATIONHUBS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateOPENAISERVICES(formats strfmt.Registry) error {
+	if swag.IsZero(m.OPENAISERVICES) { // not required
+		return nil
+	}
+
+	if m.OPENAISERVICES != nil {
+		if err := m.OPENAISERVICES.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("OPENAISERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("OPENAISERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateOPSWORKS(formats strfmt.Registry) error {
 	if swag.IsZero(m.OPSWORKS) { // not required
 		return nil
@@ -2009,6 +3111,101 @@ func (m *CloudServices) validatePOSTGRESQL(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validatePOSTGRESQLCITUS(formats strfmt.Registry) error {
+	if swag.IsZero(m.POSTGRESQLCITUS) { // not required
+		return nil
+	}
+
+	if m.POSTGRESQLCITUS != nil {
+		if err := m.POSTGRESQLCITUS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("POSTGRESQLCITUS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("POSTGRESQLCITUS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validatePOSTGRESQLFLEXIBLE(formats strfmt.Registry) error {
+	if swag.IsZero(m.POSTGRESQLFLEXIBLE) { // not required
+		return nil
+	}
+
+	if m.POSTGRESQLFLEXIBLE != nil {
+		if err := m.POSTGRESQLFLEXIBLE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("POSTGRESQLFLEXIBLE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("POSTGRESQLFLEXIBLE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validatePOWERBIEMBEDDED(formats strfmt.Registry) error {
+	if swag.IsZero(m.POWERBIEMBEDDED) { // not required
+		return nil
+	}
+
+	if m.POWERBIEMBEDDED != nil {
+		if err := m.POWERBIEMBEDDED.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("POWERBIEMBEDDED")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("POWERBIEMBEDDED")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validatePRIVATELINKENDPOINTS(formats strfmt.Registry) error {
+	if swag.IsZero(m.PRIVATELINKENDPOINTS) { // not required
+		return nil
+	}
+
+	if m.PRIVATELINKENDPOINTS != nil {
+		if err := m.PRIVATELINKENDPOINTS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKENDPOINTS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKENDPOINTS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validatePRIVATELINKSERVICES(formats strfmt.Registry) error {
+	if swag.IsZero(m.PRIVATELINKSERVICES) { // not required
+		return nil
+	}
+
+	if m.PRIVATELINKSERVICES != nil {
+		if err := m.PRIVATELINKSERVICES.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKSERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKSERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validatePUBLICIP(formats strfmt.Registry) error {
 	if swag.IsZero(m.PUBLICIP) { // not required
 		return nil
@@ -2020,6 +3217,25 @@ func (m *CloudServices) validatePUBLICIP(formats strfmt.Registry) error {
 				return ve.ValidateName("PUBLICIP")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("PUBLICIP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateQBUSINESS(formats strfmt.Registry) error {
+	if swag.IsZero(m.QBUSINESS) { // not required
+		return nil
+	}
+
+	if m.QBUSINESS != nil {
+		if err := m.QBUSINESS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QBUSINESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QBUSINESS")
 			}
 			return err
 		}
@@ -2047,6 +3263,44 @@ func (m *CloudServices) validateQUEUESTORAGE(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateQUICKSIGHTDASHBOARDS(formats strfmt.Registry) error {
+	if swag.IsZero(m.QUICKSIGHTDASHBOARDS) { // not required
+		return nil
+	}
+
+	if m.QUICKSIGHTDASHBOARDS != nil {
+		if err := m.QUICKSIGHTDASHBOARDS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDASHBOARDS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDASHBOARDS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateQUICKSIGHTDATASETS(formats strfmt.Registry) error {
+	if swag.IsZero(m.QUICKSIGHTDATASETS) { // not required
+		return nil
+	}
+
+	if m.QUICKSIGHTDATASETS != nil {
+		if err := m.QUICKSIGHTDATASETS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDATASETS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDATASETS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateRDS(formats strfmt.Registry) error {
 	if swag.IsZero(m.RDS) { // not required
 		return nil
@@ -2066,17 +3320,17 @@ func (m *CloudServices) validateRDS(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *CloudServices) validateRECOVERYPROTECTEDITEM(formats strfmt.Registry) error {
-	if swag.IsZero(m.RECOVERYPROTECTEDITEM) { // not required
+func (m *CloudServices) validateRECOVERYPROTECTEDITEMS(formats strfmt.Registry) error {
+	if swag.IsZero(m.RECOVERYPROTECTEDITEMS) { // not required
 		return nil
 	}
 
-	if m.RECOVERYPROTECTEDITEM != nil {
-		if err := m.RECOVERYPROTECTEDITEM.Validate(formats); err != nil {
+	if m.RECOVERYPROTECTEDITEMS != nil {
+		if err := m.RECOVERYPROTECTEDITEMS.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("RECOVERYPROTECTEDITEM")
+				return ve.ValidateName("RECOVERYPROTECTEDITEMS")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("RECOVERYPROTECTEDITEM")
+				return ce.ValidateName("RECOVERYPROTECTEDITEMS")
 			}
 			return err
 		}
@@ -2123,6 +3377,25 @@ func (m *CloudServices) validateREDISCACHE(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateREDISCACHEENTERPRISE(formats strfmt.Registry) error {
+	if swag.IsZero(m.REDISCACHEENTERPRISE) { // not required
+		return nil
+	}
+
+	if m.REDISCACHEENTERPRISE != nil {
+		if err := m.REDISCACHEENTERPRISE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("REDISCACHEENTERPRISE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("REDISCACHEENTERPRISE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateREDSHIFT(formats strfmt.Registry) error {
 	if swag.IsZero(m.REDSHIFT) { // not required
 		return nil
@@ -2142,6 +3415,44 @@ func (m *CloudServices) validateREDSHIFT(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateREDSHIFTSERVERLESS(formats strfmt.Registry) error {
+	if swag.IsZero(m.REDSHIFTSERVERLESS) { // not required
+		return nil
+	}
+
+	if m.REDSHIFTSERVERLESS != nil {
+		if err := m.REDSHIFTSERVERLESS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("REDSHIFTSERVERLESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("REDSHIFTSERVERLESS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateRELAYNAMESPACES(formats strfmt.Registry) error {
+	if swag.IsZero(m.RELAYNAMESPACES) { // not required
+		return nil
+	}
+
+	if m.RELAYNAMESPACES != nil {
+		if err := m.RELAYNAMESPACES.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("RELAYNAMESPACES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("RELAYNAMESPACES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateROUTE53(formats strfmt.Registry) error {
 	if swag.IsZero(m.ROUTE53) { // not required
 		return nil
@@ -2153,6 +3464,25 @@ func (m *CloudServices) validateROUTE53(formats strfmt.Registry) error {
 				return ve.ValidateName("ROUTE53")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("ROUTE53")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateROUTE53HOSTEDZONE(formats strfmt.Registry) error {
+	if swag.IsZero(m.ROUTE53HOSTEDZONE) { // not required
+		return nil
+	}
+
+	if m.ROUTE53HOSTEDZONE != nil {
+		if err := m.ROUTE53HOSTEDZONE.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ROUTE53HOSTEDZONE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ROUTE53HOSTEDZONE")
 			}
 			return err
 		}
@@ -2237,6 +3567,25 @@ func (m *CloudServices) validateSERVICEBUS(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateSERVICEFABRICMESH(formats strfmt.Registry) error {
+	if swag.IsZero(m.SERVICEFABRICMESH) { // not required
+		return nil
+	}
+
+	if m.SERVICEFABRICMESH != nil {
+		if err := m.SERVICEFABRICMESH.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("SERVICEFABRICMESH")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("SERVICEFABRICMESH")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateSES(formats strfmt.Registry) error {
 	if swag.IsZero(m.SES) { // not required
 		return nil
@@ -2248,6 +3597,25 @@ func (m *CloudServices) validateSES(formats strfmt.Registry) error {
 				return ve.ValidateName("SES")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("SES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateSIGNALR(formats strfmt.Registry) error {
+	if swag.IsZero(m.SIGNALR) { // not required
+		return nil
+	}
+
+	if m.SIGNALR != nil {
+		if err := m.SIGNALR.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("SIGNALR")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("SIGNALR")
 			}
 			return err
 		}
@@ -2389,6 +3757,25 @@ func (m *CloudServices) validateSTORAGEACCOUNT(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateSTREAMANALYTICS(formats strfmt.Registry) error {
+	if swag.IsZero(m.STREAMANALYTICS) { // not required
+		return nil
+	}
+
+	if m.STREAMANALYTICS != nil {
+		if err := m.STREAMANALYTICS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("STREAMANALYTICS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("STREAMANALYTICS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateSWFACTIVITY(formats strfmt.Registry) error {
 	if swag.IsZero(m.SWFACTIVITY) { // not required
 		return nil
@@ -2484,6 +3871,25 @@ func (m *CloudServices) validateTRAFFICMANAGER(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateTRANSFER(formats strfmt.Registry) error {
+	if swag.IsZero(m.TRANSFER) { // not required
+		return nil
+	}
+
+	if m.TRANSFER != nil {
+		if err := m.TRANSFER.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("TRANSFER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("TRANSFER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateTRANSITGATEWAY(formats strfmt.Registry) error {
 	if swag.IsZero(m.TRANSITGATEWAY) { // not required
 		return nil
@@ -2503,6 +3909,25 @@ func (m *CloudServices) validateTRANSITGATEWAY(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CloudServices) validateTRANSITGATEWAYATTACHMENT(formats strfmt.Registry) error {
+	if swag.IsZero(m.TRANSITGATEWAYATTACHMENT) { // not required
+		return nil
+	}
+
+	if m.TRANSITGATEWAYATTACHMENT != nil {
+		if err := m.TRANSITGATEWAYATTACHMENT.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("TRANSITGATEWAYATTACHMENT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("TRANSITGATEWAYATTACHMENT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateVIRTUALDESKTOP(formats strfmt.Registry) error {
 	if swag.IsZero(m.VIRTUALDESKTOP) { // not required
 		return nil
@@ -2514,6 +3939,25 @@ func (m *CloudServices) validateVIRTUALDESKTOP(formats strfmt.Registry) error {
 				return ve.ValidateName("VIRTUALDESKTOP")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("VIRTUALDESKTOP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateVIRTUALHUBS(formats strfmt.Registry) error {
+	if swag.IsZero(m.VIRTUALHUBS) { // not required
+		return nil
+	}
+
+	if m.VIRTUALHUBS != nil {
+		if err := m.VIRTUALHUBS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("VIRTUALHUBS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("VIRTUALHUBS")
 			}
 			return err
 		}
@@ -2598,6 +4042,25 @@ func (m *CloudServices) validateVIRTUALNETWORKGATEWAY(formats strfmt.Registry) e
 	return nil
 }
 
+func (m *CloudServices) validateVIRTUALNETWORKS(formats strfmt.Registry) error {
+	if swag.IsZero(m.VIRTUALNETWORKS) { // not required
+		return nil
+	}
+
+	if m.VIRTUALNETWORKS != nil {
+		if err := m.VIRTUALNETWORKS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("VIRTUALNETWORKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("VIRTUALNETWORKS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) validateVPN(formats strfmt.Registry) error {
 	if swag.IsZero(m.VPN) { // not required
 		return nil
@@ -2609,6 +4072,25 @@ func (m *CloudServices) validateVPN(formats strfmt.Registry) error {
 				return ve.ValidateName("VPN")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("VPN")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) validateVPNGATEWAYS(formats strfmt.Registry) error {
+	if swag.IsZero(m.VPNGATEWAYS) { // not required
+		return nil
+	}
+
+	if m.VPNGATEWAYS != nil {
+		if err := m.VPNGATEWAYS.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("VPNGATEWAYS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("VPNGATEWAYS")
 			}
 			return err
 		}
@@ -2659,7 +4141,27 @@ func (m *CloudServices) validateWORKSPACEDIRECTORY(formats strfmt.Registry) erro
 func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateACM(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateAKSMANAGEDCLUSTER(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateALARMS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateANALYSISSERVICE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateAPIGATEWAY(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateAPIGATEWAYV2(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2679,7 +4181,15 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateAPPLICATIONMIGRATIONSERVICE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateAPPSERVICE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateAPPSERVICEENVIRONMENT(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2703,11 +4213,35 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateBACKUP(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateBACKUPPROTECTEDITEMS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateBACKUPPROTECTEDRESOURCE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateBATCHACCOUNT(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateBEDROCK(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateBLOBSTORAGE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateBOTSERVICES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateCDNPROFILE(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2735,7 +4269,23 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateCONTAINERAPPS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateCONTAINERINSTANCE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateCONTAINERREGISTRY(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateCOSMOSDB(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDATABRICKS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2743,7 +4293,27 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateDATALAKEANALYTICS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDATALAKESTORE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDBCLUSTER(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateDIRECTCONNECT(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDIRECTCONNECTVIRTUALINTERFACE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDISKS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2771,11 +4341,19 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateECR(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateECS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.contextValidateEFS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateEKS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2807,6 +4385,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateEVENTGRID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateEVENTHUB(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -2835,7 +4417,27 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateFUNCTION(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGATEWAYELB(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGLOBALNETWORKS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateGLUE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateHDINSIGHT(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateIOTHUB(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2867,6 +4469,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateMARIADB(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateMEDIACONNECT(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -2891,6 +4497,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateMLWORKSPACES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateMQ(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -2907,7 +4517,19 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateMYSQLFLEXIBLE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateNATGATEWAY(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateNATGATEWAYS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateNETAPPPOOLS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2919,6 +4541,14 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateNOTIFICATIONHUBS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateOPENAISERVICES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateOPSWORKS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -2927,7 +4557,31 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidatePOSTGRESQLCITUS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePOSTGRESQLFLEXIBLE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePOWERBIEMBEDDED(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePRIVATELINKENDPOINTS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePRIVATELINKSERVICES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidatePUBLICIP(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateQBUSINESS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2935,11 +4589,19 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateQUICKSIGHTDASHBOARDS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateQUICKSIGHTDATASETS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRDS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateRECOVERYPROTECTEDITEM(ctx, formats); err != nil {
+	if err := m.contextValidateRECOVERYPROTECTEDITEMS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2951,11 +4613,27 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateREDISCACHEENTERPRISE(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateREDSHIFT(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateREDSHIFTSERVERLESS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRELAYNAMESPACES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateROUTE53(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateROUTE53HOSTEDZONE(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -2975,7 +4653,15 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateSERVICEFABRICMESH(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateSES(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSIGNALR(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -3007,6 +4693,10 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateSTREAMANALYTICS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateSWFACTIVITY(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -3027,11 +4717,23 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTRANSFER(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateTRANSITGATEWAY(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTRANSITGATEWAYATTACHMENT(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateVIRTUALDESKTOP(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateVIRTUALHUBS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -3051,7 +4753,15 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateVIRTUALNETWORKS(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateVPN(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateVPNGATEWAYS(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -3069,6 +4779,70 @@ func (m *CloudServices) ContextValidate(ctx context.Context, formats strfmt.Regi
 	return nil
 }
 
+func (m *CloudServices) contextValidateACM(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ACM != nil {
+		if err := m.ACM.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ACM")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ACM")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateAKSMANAGEDCLUSTER(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.AKSMANAGEDCLUSTER != nil {
+		if err := m.AKSMANAGEDCLUSTER.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("AKSMANAGEDCLUSTER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("AKSMANAGEDCLUSTER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateALARMS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ALARMS != nil {
+		if err := m.ALARMS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ALARMS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ALARMS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateANALYSISSERVICE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ANALYSISSERVICE != nil {
+		if err := m.ANALYSISSERVICE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ANALYSISSERVICE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ANALYSISSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateAPIGATEWAY(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.APIGATEWAY != nil {
@@ -3077,6 +4851,22 @@ func (m *CloudServices) contextValidateAPIGATEWAY(ctx context.Context, formats s
 				return ve.ValidateName("APIGATEWAY")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("APIGATEWAY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateAPIGATEWAYV2(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.APIGATEWAYV2 != nil {
+		if err := m.APIGATEWAYV2.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APIGATEWAYV2")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APIGATEWAYV2")
 			}
 			return err
 		}
@@ -3149,6 +4939,22 @@ func (m *CloudServices) contextValidateAPPLICATIONINSIGHTS(ctx context.Context, 
 	return nil
 }
 
+func (m *CloudServices) contextValidateAPPLICATIONMIGRATIONSERVICE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.APPLICATIONMIGRATIONSERVICE != nil {
+		if err := m.APPLICATIONMIGRATIONSERVICE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APPLICATIONMIGRATIONSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateAPPSERVICE(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.APPSERVICE != nil {
@@ -3157,6 +4963,22 @@ func (m *CloudServices) contextValidateAPPSERVICE(ctx context.Context, formats s
 				return ve.ValidateName("APPSERVICE")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("APPSERVICE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateAPPSERVICEENVIRONMENT(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.APPSERVICEENVIRONMENT != nil {
+		if err := m.APPSERVICEENVIRONMENT.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("APPSERVICEENVIRONMENT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("APPSERVICEENVIRONMENT")
 			}
 			return err
 		}
@@ -3245,6 +5067,22 @@ func (m *CloudServices) contextValidateAUTOSCALING(ctx context.Context, formats 
 	return nil
 }
 
+func (m *CloudServices) contextValidateBACKUP(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BACKUP != nil {
+		if err := m.BACKUP.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUP")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateBACKUPPROTECTEDITEMS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.BACKUPPROTECTEDITEMS != nil {
@@ -3261,6 +5099,54 @@ func (m *CloudServices) contextValidateBACKUPPROTECTEDITEMS(ctx context.Context,
 	return nil
 }
 
+func (m *CloudServices) contextValidateBACKUPPROTECTEDRESOURCE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BACKUPPROTECTEDRESOURCE != nil {
+		if err := m.BACKUPPROTECTEDRESOURCE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BACKUPPROTECTEDRESOURCE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BACKUPPROTECTEDRESOURCE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateBATCHACCOUNT(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BATCHACCOUNT != nil {
+		if err := m.BATCHACCOUNT.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BATCHACCOUNT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BATCHACCOUNT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateBEDROCK(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BEDROCK != nil {
+		if err := m.BEDROCK.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BEDROCK")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BEDROCK")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateBLOBSTORAGE(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.BLOBSTORAGE != nil {
@@ -3269,6 +5155,38 @@ func (m *CloudServices) contextValidateBLOBSTORAGE(ctx context.Context, formats 
 				return ve.ValidateName("BLOBSTORAGE")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("BLOBSTORAGE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateBOTSERVICES(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.BOTSERVICES != nil {
+		if err := m.BOTSERVICES.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("BOTSERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("BOTSERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateCDNPROFILE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.CDNPROFILE != nil {
+		if err := m.CDNPROFILE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CDNPROFILE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CDNPROFILE")
 			}
 			return err
 		}
@@ -3373,6 +5291,54 @@ func (m *CloudServices) contextValidateCOGNITO(ctx context.Context, formats strf
 	return nil
 }
 
+func (m *CloudServices) contextValidateCONTAINERAPPS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.CONTAINERAPPS != nil {
+		if err := m.CONTAINERAPPS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CONTAINERAPPS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CONTAINERAPPS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateCONTAINERINSTANCE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.CONTAINERINSTANCE != nil {
+		if err := m.CONTAINERINSTANCE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CONTAINERINSTANCE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CONTAINERINSTANCE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateCONTAINERREGISTRY(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.CONTAINERREGISTRY != nil {
+		if err := m.CONTAINERREGISTRY.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("CONTAINERREGISTRY")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("CONTAINERREGISTRY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateCOSMOSDB(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.COSMOSDB != nil {
@@ -3381,6 +5347,22 @@ func (m *CloudServices) contextValidateCOSMOSDB(ctx context.Context, formats str
 				return ve.ValidateName("COSMOSDB")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("COSMOSDB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDATABRICKS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DATABRICKS != nil {
+		if err := m.DATABRICKS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DATABRICKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DATABRICKS")
 			}
 			return err
 		}
@@ -3405,6 +5387,54 @@ func (m *CloudServices) contextValidateDATAFACTORY(ctx context.Context, formats 
 	return nil
 }
 
+func (m *CloudServices) contextValidateDATALAKEANALYTICS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DATALAKEANALYTICS != nil {
+		if err := m.DATALAKEANALYTICS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DATALAKEANALYTICS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DATALAKEANALYTICS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDATALAKESTORE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DATALAKESTORE != nil {
+		if err := m.DATALAKESTORE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DATALAKESTORE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DATALAKESTORE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDBCLUSTER(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DBCLUSTER != nil {
+		if err := m.DBCLUSTER.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DBCLUSTER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DBCLUSTER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateDIRECTCONNECT(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.DIRECTCONNECT != nil {
@@ -3413,6 +5443,38 @@ func (m *CloudServices) contextValidateDIRECTCONNECT(ctx context.Context, format
 				return ve.ValidateName("DIRECTCONNECT")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("DIRECTCONNECT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDIRECTCONNECTVIRTUALINTERFACE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DIRECTCONNECTVIRTUALINTERFACE != nil {
+		if err := m.DIRECTCONNECTVIRTUALINTERFACE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DIRECTCONNECTVIRTUALINTERFACE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateDISKS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DISKS != nil {
+		if err := m.DISKS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("DISKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("DISKS")
 			}
 			return err
 		}
@@ -3517,6 +5579,22 @@ func (m *CloudServices) contextValidateEC2(ctx context.Context, formats strfmt.R
 	return nil
 }
 
+func (m *CloudServices) contextValidateECR(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ECR != nil {
+		if err := m.ECR.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ECR")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ECR")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateECS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ECS != nil {
@@ -3541,6 +5619,22 @@ func (m *CloudServices) contextValidateEFS(ctx context.Context, formats strfmt.R
 				return ve.ValidateName("EFS")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("EFS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateEKS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.EKS != nil {
+		if err := m.EKS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("EKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("EKS")
 			}
 			return err
 		}
@@ -3661,6 +5755,22 @@ func (m *CloudServices) contextValidateEVENTBRIDGE(ctx context.Context, formats 
 	return nil
 }
 
+func (m *CloudServices) contextValidateEVENTGRID(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.EVENTGRID != nil {
+		if err := m.EVENTGRID.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("EVENTGRID")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("EVENTGRID")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateEVENTHUB(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.EVENTHUB != nil {
@@ -3773,6 +5883,54 @@ func (m *CloudServices) contextValidateFSX(ctx context.Context, formats strfmt.R
 	return nil
 }
 
+func (m *CloudServices) contextValidateFUNCTION(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.FUNCTION != nil {
+		if err := m.FUNCTION.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("FUNCTION")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("FUNCTION")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateGATEWAYELB(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.GATEWAYELB != nil {
+		if err := m.GATEWAYELB.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("GATEWAYELB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("GATEWAYELB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateGLOBALNETWORKS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.GLOBALNETWORKS != nil {
+		if err := m.GLOBALNETWORKS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("GLOBALNETWORKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("GLOBALNETWORKS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateGLUE(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.GLUE != nil {
@@ -3781,6 +5939,38 @@ func (m *CloudServices) contextValidateGLUE(ctx context.Context, formats strfmt.
 				return ve.ValidateName("GLUE")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("GLUE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateHDINSIGHT(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.HDINSIGHT != nil {
+		if err := m.HDINSIGHT.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("HDINSIGHT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("HDINSIGHT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateIOTHUB(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.IOTHUB != nil {
+		if err := m.IOTHUB.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("IOTHUB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("IOTHUB")
 			}
 			return err
 		}
@@ -3901,6 +6091,22 @@ func (m *CloudServices) contextValidateLOGICAPPS(ctx context.Context, formats st
 	return nil
 }
 
+func (m *CloudServices) contextValidateMARIADB(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.MARIADB != nil {
+		if err := m.MARIADB.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("MARIADB")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("MARIADB")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateMEDIACONNECT(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MEDIACONNECT != nil {
@@ -3997,6 +6203,22 @@ func (m *CloudServices) contextValidateMEDIATAILOR(ctx context.Context, formats 
 	return nil
 }
 
+func (m *CloudServices) contextValidateMLWORKSPACES(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.MLWORKSPACES != nil {
+		if err := m.MLWORKSPACES.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("MLWORKSPACES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("MLWORKSPACES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateMQ(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MQ != nil {
@@ -4061,6 +6283,22 @@ func (m *CloudServices) contextValidateMYSQL(ctx context.Context, formats strfmt
 	return nil
 }
 
+func (m *CloudServices) contextValidateMYSQLFLEXIBLE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.MYSQLFLEXIBLE != nil {
+		if err := m.MYSQLFLEXIBLE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("MYSQLFLEXIBLE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("MYSQLFLEXIBLE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateNATGATEWAY(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.NATGATEWAY != nil {
@@ -4069,6 +6307,38 @@ func (m *CloudServices) contextValidateNATGATEWAY(ctx context.Context, formats s
 				return ve.ValidateName("NATGATEWAY")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("NATGATEWAY")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateNATGATEWAYS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.NATGATEWAYS != nil {
+		if err := m.NATGATEWAYS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("NATGATEWAYS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("NATGATEWAYS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateNETAPPPOOLS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.NETAPPPOOLS != nil {
+		if err := m.NETAPPPOOLS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("NETAPPPOOLS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("NETAPPPOOLS")
 			}
 			return err
 		}
@@ -4109,6 +6379,38 @@ func (m *CloudServices) contextValidateNETWORKINTERFACE(ctx context.Context, for
 	return nil
 }
 
+func (m *CloudServices) contextValidateNOTIFICATIONHUBS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.NOTIFICATIONHUBS != nil {
+		if err := m.NOTIFICATIONHUBS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("NOTIFICATIONHUBS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("NOTIFICATIONHUBS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateOPENAISERVICES(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.OPENAISERVICES != nil {
+		if err := m.OPENAISERVICES.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("OPENAISERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("OPENAISERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateOPSWORKS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.OPSWORKS != nil {
@@ -4141,6 +6443,86 @@ func (m *CloudServices) contextValidatePOSTGRESQL(ctx context.Context, formats s
 	return nil
 }
 
+func (m *CloudServices) contextValidatePOSTGRESQLCITUS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.POSTGRESQLCITUS != nil {
+		if err := m.POSTGRESQLCITUS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("POSTGRESQLCITUS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("POSTGRESQLCITUS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidatePOSTGRESQLFLEXIBLE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.POSTGRESQLFLEXIBLE != nil {
+		if err := m.POSTGRESQLFLEXIBLE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("POSTGRESQLFLEXIBLE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("POSTGRESQLFLEXIBLE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidatePOWERBIEMBEDDED(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.POWERBIEMBEDDED != nil {
+		if err := m.POWERBIEMBEDDED.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("POWERBIEMBEDDED")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("POWERBIEMBEDDED")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidatePRIVATELINKENDPOINTS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PRIVATELINKENDPOINTS != nil {
+		if err := m.PRIVATELINKENDPOINTS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKENDPOINTS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKENDPOINTS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidatePRIVATELINKSERVICES(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PRIVATELINKSERVICES != nil {
+		if err := m.PRIVATELINKSERVICES.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("PRIVATELINKSERVICES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("PRIVATELINKSERVICES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidatePUBLICIP(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PUBLICIP != nil {
@@ -4149,6 +6531,22 @@ func (m *CloudServices) contextValidatePUBLICIP(ctx context.Context, formats str
 				return ve.ValidateName("PUBLICIP")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("PUBLICIP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateQBUSINESS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.QBUSINESS != nil {
+		if err := m.QBUSINESS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QBUSINESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QBUSINESS")
 			}
 			return err
 		}
@@ -4173,6 +6571,38 @@ func (m *CloudServices) contextValidateQUEUESTORAGE(ctx context.Context, formats
 	return nil
 }
 
+func (m *CloudServices) contextValidateQUICKSIGHTDASHBOARDS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.QUICKSIGHTDASHBOARDS != nil {
+		if err := m.QUICKSIGHTDASHBOARDS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDASHBOARDS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDASHBOARDS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateQUICKSIGHTDATASETS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.QUICKSIGHTDATASETS != nil {
+		if err := m.QUICKSIGHTDATASETS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("QUICKSIGHTDATASETS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("QUICKSIGHTDATASETS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateRDS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.RDS != nil {
@@ -4189,14 +6619,14 @@ func (m *CloudServices) contextValidateRDS(ctx context.Context, formats strfmt.R
 	return nil
 }
 
-func (m *CloudServices) contextValidateRECOVERYPROTECTEDITEM(ctx context.Context, formats strfmt.Registry) error {
+func (m *CloudServices) contextValidateRECOVERYPROTECTEDITEMS(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.RECOVERYPROTECTEDITEM != nil {
-		if err := m.RECOVERYPROTECTEDITEM.ContextValidate(ctx, formats); err != nil {
+	if m.RECOVERYPROTECTEDITEMS != nil {
+		if err := m.RECOVERYPROTECTEDITEMS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("RECOVERYPROTECTEDITEM")
+				return ve.ValidateName("RECOVERYPROTECTEDITEMS")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("RECOVERYPROTECTEDITEM")
+				return ce.ValidateName("RECOVERYPROTECTEDITEMS")
 			}
 			return err
 		}
@@ -4237,6 +6667,22 @@ func (m *CloudServices) contextValidateREDISCACHE(ctx context.Context, formats s
 	return nil
 }
 
+func (m *CloudServices) contextValidateREDISCACHEENTERPRISE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.REDISCACHEENTERPRISE != nil {
+		if err := m.REDISCACHEENTERPRISE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("REDISCACHEENTERPRISE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("REDISCACHEENTERPRISE")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateREDSHIFT(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.REDSHIFT != nil {
@@ -4253,6 +6699,38 @@ func (m *CloudServices) contextValidateREDSHIFT(ctx context.Context, formats str
 	return nil
 }
 
+func (m *CloudServices) contextValidateREDSHIFTSERVERLESS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.REDSHIFTSERVERLESS != nil {
+		if err := m.REDSHIFTSERVERLESS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("REDSHIFTSERVERLESS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("REDSHIFTSERVERLESS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateRELAYNAMESPACES(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.RELAYNAMESPACES != nil {
+		if err := m.RELAYNAMESPACES.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("RELAYNAMESPACES")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("RELAYNAMESPACES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateROUTE53(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ROUTE53 != nil {
@@ -4261,6 +6739,22 @@ func (m *CloudServices) contextValidateROUTE53(ctx context.Context, formats strf
 				return ve.ValidateName("ROUTE53")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("ROUTE53")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateROUTE53HOSTEDZONE(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ROUTE53HOSTEDZONE != nil {
+		if err := m.ROUTE53HOSTEDZONE.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ROUTE53HOSTEDZONE")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("ROUTE53HOSTEDZONE")
 			}
 			return err
 		}
@@ -4333,6 +6827,22 @@ func (m *CloudServices) contextValidateSERVICEBUS(ctx context.Context, formats s
 	return nil
 }
 
+func (m *CloudServices) contextValidateSERVICEFABRICMESH(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SERVICEFABRICMESH != nil {
+		if err := m.SERVICEFABRICMESH.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("SERVICEFABRICMESH")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("SERVICEFABRICMESH")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateSES(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SES != nil {
@@ -4341,6 +6851,22 @@ func (m *CloudServices) contextValidateSES(ctx context.Context, formats strfmt.R
 				return ve.ValidateName("SES")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("SES")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateSIGNALR(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SIGNALR != nil {
+		if err := m.SIGNALR.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("SIGNALR")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("SIGNALR")
 			}
 			return err
 		}
@@ -4461,6 +6987,22 @@ func (m *CloudServices) contextValidateSTORAGEACCOUNT(ctx context.Context, forma
 	return nil
 }
 
+func (m *CloudServices) contextValidateSTREAMANALYTICS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.STREAMANALYTICS != nil {
+		if err := m.STREAMANALYTICS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("STREAMANALYTICS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("STREAMANALYTICS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateSWFACTIVITY(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SWFACTIVITY != nil {
@@ -4541,6 +7083,22 @@ func (m *CloudServices) contextValidateTRAFFICMANAGER(ctx context.Context, forma
 	return nil
 }
 
+func (m *CloudServices) contextValidateTRANSFER(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.TRANSFER != nil {
+		if err := m.TRANSFER.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("TRANSFER")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("TRANSFER")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateTRANSITGATEWAY(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TRANSITGATEWAY != nil {
@@ -4557,6 +7115,22 @@ func (m *CloudServices) contextValidateTRANSITGATEWAY(ctx context.Context, forma
 	return nil
 }
 
+func (m *CloudServices) contextValidateTRANSITGATEWAYATTACHMENT(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.TRANSITGATEWAYATTACHMENT != nil {
+		if err := m.TRANSITGATEWAYATTACHMENT.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("TRANSITGATEWAYATTACHMENT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("TRANSITGATEWAYATTACHMENT")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateVIRTUALDESKTOP(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.VIRTUALDESKTOP != nil {
@@ -4565,6 +7139,22 @@ func (m *CloudServices) contextValidateVIRTUALDESKTOP(ctx context.Context, forma
 				return ve.ValidateName("VIRTUALDESKTOP")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("VIRTUALDESKTOP")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateVIRTUALHUBS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.VIRTUALHUBS != nil {
+		if err := m.VIRTUALHUBS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("VIRTUALHUBS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("VIRTUALHUBS")
 			}
 			return err
 		}
@@ -4637,6 +7227,22 @@ func (m *CloudServices) contextValidateVIRTUALNETWORKGATEWAY(ctx context.Context
 	return nil
 }
 
+func (m *CloudServices) contextValidateVIRTUALNETWORKS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.VIRTUALNETWORKS != nil {
+		if err := m.VIRTUALNETWORKS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("VIRTUALNETWORKS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("VIRTUALNETWORKS")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *CloudServices) contextValidateVPN(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.VPN != nil {
@@ -4645,6 +7251,22 @@ func (m *CloudServices) contextValidateVPN(ctx context.Context, formats strfmt.R
 				return ve.ValidateName("VPN")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("VPN")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *CloudServices) contextValidateVPNGATEWAYS(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.VPNGATEWAYS != nil {
+		if err := m.VPNGATEWAYS.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("VPNGATEWAYS")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("VPNGATEWAYS")
 			}
 			return err
 		}

--- a/website/docs/r/device_group.markdown
+++ b/website/docs/r/device_group.markdown
@@ -153,6 +153,10 @@ resource "logicmonitor_device_group" "my_aws_device_group" {
 		null_resource.wait,
 	]
 }
+
+Note: The following services are currently not supported by the Terraform Provider: directconnectvirtualinterface, globalnetworks, privatelinkservices, privatelinkendpoints, quicksightdashboards, quicksightdatasets.
+Support for these services may be added in future releases.
+
 ```
 ## Example Usage - Azure Cloud Account
 ```hcl
@@ -214,7 +218,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -234,7 +238,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -255,7 +259,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -276,7 +280,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -297,7 +301,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -317,7 +321,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -337,7 +341,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -357,7 +361,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -377,7 +381,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -397,7 +401,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -417,7 +421,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -437,7 +441,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -457,7 +461,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -477,7 +481,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true
@@ -497,7 +501,7 @@ resource "logicmonitor_device_group" "my_azure_device_group" {
         disable_terminated_host_alerting = true
         normal_collector_config {
           collectors = []
-          enabled    = false
+          enable    = false
         }
         custom_n_s_p_schedule = ""
         select_all            = true


### PR DESCRIPTION
AWS and Azure Additional Services Added

Note: The following services are currently not supported by the Terraform Provider: directconnectvirtualinterface, globalnetworks, privatelinkservices, privatelinkendpoints, quicksightdashboards, quicksightdatasets.
Support for these services may be added in future releases.