### PR TITLE
fix(aws-external-id): correct schema, resource ID, and nil safety

### DIFF
--- a/logicmonitor/resources/data_resource_aws_external_id_resource.go
+++ b/logicmonitor/resources/data_resource_aws_external_id_resource.go
@@ -42,6 +42,10 @@ func getAwsExternalId(ctx context.Context, d *schema.ResourceData, m interface{}
 	}
 
 	respModel := resp.GetPayload()
+	if respModel == nil {
+		diags = append(diags, diag.Errorf("no AWS external ID returned from API")...)
+		return diags
+	}
 	schemata.SetAwsExternalIDResourceData(d, respModel)
 	return diags
 }

--- a/logicmonitor/schemata/aws_external_id_schema.go
+++ b/logicmonitor/schemata/aws_external_id_schema.go
@@ -1,8 +1,6 @@
 package schemata
 
 import (
-	"strconv"
-	"time"
 	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -11,12 +9,12 @@ func AwsExternalIDSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"created_at": {
 			Type: schema.TypeString,
-			Optional: true,
+			Computed: true,
 		},
-		
+
 		"external_id": {
 			Type: schema.TypeString,
-			Optional: true,
+			Computed: true,
 		},
 		
 	}
@@ -25,7 +23,7 @@ func AwsExternalIDSchema() map[string]*schema.Schema {
 func SetAwsExternalIDResourceData(d *schema.ResourceData, m *models.AwsExternalID) {
 	d.Set("created_at", m.CreatedAt)
 	d.Set("external_id", m.ExternalID)
-	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+	d.SetId(m.ExternalID)
 }
 
 func SetAwsExternalIDSubResourceData(m []*models.AwsExternalID) (d []*map[string]interface{}) {

--- a/logicmonitor/schemata/aws_external_id_schema_test.go
+++ b/logicmonitor/schemata/aws_external_id_schema_test.go
@@ -1,0 +1,117 @@
+// Description: Unit tests for AWS External ID schema and resource data functions.
+// Description: Validates Computed fields, resource ID assignment, and nil handling.
+package schemata
+
+import (
+	"terraform-provider-logicmonitor/models"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAwsExternalIDSchemaFieldsAreComputed(t *testing.T) {
+	s := AwsExternalIDSchema()
+
+	tests := []struct {
+		field string
+	}{
+		{"created_at"},
+		{"external_id"},
+	}
+
+	for _, tt := range tests {
+		f, ok := s[tt.field]
+		if !ok {
+			t.Errorf("expected field %q in schema", tt.field)
+			continue
+		}
+		if !f.Computed {
+			t.Errorf("field %q should be Computed", tt.field)
+		}
+		if f.Optional {
+			t.Errorf("field %q should not be Optional", tt.field)
+		}
+	}
+}
+
+func TestSetAwsExternalIDResourceDataSetsID(t *testing.T) {
+	resourceSchema := map[string]*schema.Schema{
+		"created_at":  {Type: schema.TypeString, Computed: true},
+		"external_id": {Type: schema.TypeString, Computed: true},
+	}
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{})
+
+	model := &models.AwsExternalID{
+		CreatedAt:  "2026-04-02T12:07:00Z",
+		ExternalID: "0dfc2264-482c-4f74-b8b9-ceb7604c7492",
+	}
+
+	SetAwsExternalIDResourceData(d, model)
+
+	if got := d.Id(); got != "0dfc2264-482c-4f74-b8b9-ceb7604c7492" {
+		t.Errorf("expected ID to be the ExternalID UUID, got %q", got)
+	}
+	if got := d.Get("created_at").(string); got != "2026-04-02T12:07:00Z" {
+		t.Errorf("expected created_at %q, got %q", "2026-04-02T12:07:00Z", got)
+	}
+	if got := d.Get("external_id").(string); got != "0dfc2264-482c-4f74-b8b9-ceb7604c7492" {
+		t.Errorf("expected external_id %q, got %q", "0dfc2264-482c-4f74-b8b9-ceb7604c7492", got)
+	}
+}
+
+func TestSetAwsExternalIDResourceDataIDIsStable(t *testing.T) {
+	resourceSchema := map[string]*schema.Schema{
+		"created_at":  {Type: schema.TypeString, Computed: true},
+		"external_id": {Type: schema.TypeString, Computed: true},
+	}
+
+	model := &models.AwsExternalID{
+		CreatedAt:  "2026-04-02T12:07:00Z",
+		ExternalID: "abc-123-def-456",
+	}
+
+	// Call twice and verify the ID is the same (not timestamp-based)
+	d1 := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{})
+	SetAwsExternalIDResourceData(d1, model)
+
+	d2 := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{})
+	SetAwsExternalIDResourceData(d2, model)
+
+	if d1.Id() != d2.Id() {
+		t.Errorf("resource ID should be stable across calls, got %q and %q", d1.Id(), d2.Id())
+	}
+}
+
+func TestSetAwsExternalIDSubResourceDataHandlesNil(t *testing.T) {
+	result := SetAwsExternalIDSubResourceData(nil)
+	if result != nil {
+		t.Errorf("expected nil for nil input, got %v", result)
+	}
+
+	result = SetAwsExternalIDSubResourceData([]*models.AwsExternalID{nil})
+	if result != nil {
+		t.Errorf("expected nil for slice with nil element, got %v", result)
+	}
+}
+
+func TestSetAwsExternalIDSubResourceDataPopulatesFields(t *testing.T) {
+	input := []*models.AwsExternalID{
+		{
+			CreatedAt:  "2026-04-02T12:07:00Z",
+			ExternalID: "test-uuid-123",
+		},
+	}
+
+	result := SetAwsExternalIDSubResourceData(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	props := *result[0]
+	if props["created_at"] != "2026-04-02T12:07:00Z" {
+		t.Errorf("expected created_at %q, got %q", "2026-04-02T12:07:00Z", props["created_at"])
+	}
+	if props["external_id"] != "test-uuid-123" {
+		t.Errorf("expected external_id %q, got %q", "test-uuid-123", props["external_id"])
+	}
+}


### PR DESCRIPTION
## Summary

- Change `external_id` and `created_at` fields from `Optional` to `Computed` since they are read-only API outputs, not user inputs
- Use the API-returned `ExternalID` UUID as the resource ID instead of `time.Now().Unix()` which caused state churn on every read
- Add nil check on `GetPayload()` response to prevent nil pointer panic when API returns empty body

Fixes #44

## Files Changed

- `logicmonitor/schemata/aws_external_id_schema.go` — schema fields, SetId fix, import cleanup
- `logicmonitor/resources/data_resource_aws_external_id_resource.go` — nil check on API response
- `logicmonitor/schemata/aws_external_id_schema_test.go` — unit tests (5 tests)

## Testing

- Unit tests: `go test ./logicmonitor/schemata/ -run Aws -v` (5/5 pass)
- Live portal validation: tested against a live LogicMonitor portal (`lmryanmatuszewski`) using Terraform 1.14.8
  - `data.logicmonitor_data_resource_aws_external_id` returns Computed fields (`external_id`, `created_at`) correctly
  - Resource ID is now the ExternalID UUID (e.g., `6a04d839-5cce-4eef-a38a-8f3b5b2048c9`), not a Unix timestamp
  - `terraform plan` shows 0 changes after apply

## Note on upstream API behavior

The LM `GET /aws/externalId` endpoint is generative — each call creates a new UUID. This is an API-side issue, not fixable in the provider. The provider-side fix eliminates the state churn caused by timestamp-based IDs and makes the data source usable for single-apply workflows.