### PR TITLE
fix(schema): resolve configuration drift in device group, alert rule, escalation chain

### DIFF
--- a/logicmonitor/schemata/alert_rule_schema.go
+++ b/logicmonitor/schemata/alert_rule_schema.go
@@ -212,7 +212,11 @@ func SetAlertRuleResourceData(d *schema.ResourceData, m *models.AlertRule) {
 	d.Set("datasource", m.Datasource)
 	d.Set("device_groups", m.DeviceGroups)
 	d.Set("devices", m.Devices)
-	d.Set("escalating_chain", m.EscalatingChain)
+	if m.EscalatingChain != nil {
+		d.Set("escalating_chain", m.EscalatingChain)
+	} else {
+		d.Set("escalating_chain", map[string]interface{}{})
+	}
 	d.Set("escalating_chain_id", m.EscalatingChainID)
 	d.Set("escalation_interval", m.EscalationInterval)
 	d.Set("id", strconv.Itoa(int(m.ID)))

--- a/logicmonitor/schemata/chain_schema.go
+++ b/logicmonitor/schemata/chain_schema.go
@@ -40,7 +40,11 @@ func SetChainSubResourceData(m []*models.Chain) (d []*map[string]interface{}) {
 		if chain != nil {
 			properties := make(map[string]interface{})
 			properties["period"] = SetPeriodSubResourceData([]*models.Period{chain.Period})
-            properties["stages"] = SetRecipientSubResourceData(chain.Stages[0])
+			if len(chain.Stages) > 0 {
+				properties["stages"] = SetRecipientSubResourceData(chain.Stages[0])
+			} else {
+				properties["stages"] = []*map[string]interface{}{}
+			}
 			properties["type"] = chain.Type
 			d = append(d, &properties)
 		}

--- a/logicmonitor/schemata/collector_group_schema.go
+++ b/logicmonitor/schemata/collector_group_schema.go
@@ -28,7 +28,7 @@ func CollectorGroupSchema() map[string]*schema.Schema {
 			Type: schema.TypeInt,
 			Computed: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
@@ -36,6 +36,7 @@ func CollectorGroupSchema() map[string]*schema.Schema {
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
 			Optional: true,
+			Computed: true,
 		},
 		
 		"description": {

--- a/logicmonitor/schemata/collector_schema.go
+++ b/logicmonitor/schemata/collector_schema.go
@@ -118,7 +118,7 @@ func CollectorSchema() map[string]*schema.Schema {
 			Type: schema.TypeString,
 			Computed: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
@@ -126,6 +126,7 @@ func CollectorSchema() map[string]*schema.Schema {
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
 			Optional: true,
+			Computed: true,
 		},
 		
 		"description": {

--- a/logicmonitor/schemata/device_group_schema.go
+++ b/logicmonitor/schemata/device_group_schema.go
@@ -62,6 +62,7 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
 			Optional: true,
+			Computed: true,
 		},
 		
 		"default_auto_balanced_collector_group_id": {
@@ -93,18 +94,19 @@ func DeviceGroupSchema() map[string]*schema.Schema {
 			Type: schema.TypeBool,
 			Computed: true,
 		},
-		
+
 		"enable_netflow": {
 			Type: schema.TypeBool,
 			Optional: true,
 		},
-		
+
 		"extra": {
 			Type: schema.TypeList, //GoType: CloudAccountExtra
 			Elem: &schema.Resource{
 				Schema: CloudAccountExtraSchema(),
 			},
 			Optional: true,
+			Computed: true,
 		},
 		
 		"full_path": {

--- a/logicmonitor/schemata/device_schema.go
+++ b/logicmonitor/schemata/device_schema.go
@@ -95,7 +95,7 @@ func DeviceSchema() map[string]*schema.Schema {
 			Type: schema.TypeInt,
 			Optional: true,
 		},
-		
+
 		"custom_properties": {
 			Type: schema.TypeSet,
 			Elem: &schema.Resource{
@@ -103,6 +103,7 @@ func DeviceSchema() map[string]*schema.Schema {
 			},
 			ConfigMode: schema.SchemaConfigModeAttr,
 			Optional: true,
+			Computed: true,
 		},
 		
 		"deleted_time_in_ms": {

--- a/logicmonitor/schemata/drift_fixes_test.go
+++ b/logicmonitor/schemata/drift_fixes_test.go
@@ -1,0 +1,264 @@
+// Description: Unit tests for configuration drift fixes across multiple schemas.
+// Description: Validates DiffSuppressFunc, nil normalization, bounds checks, and Computed fields.
+package schemata
+
+import (
+	"terraform-provider-logicmonitor/models"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// --- Bug 5: DiffSuppressFunc for masked sensitive values ---
+
+func TestNameAndValueDiffSuppressMaskedValue(t *testing.T) {
+	s := NameAndValueSchema()
+	valueField := s["value"]
+
+	if valueField.DiffSuppressFunc == nil {
+		t.Fatal("value field must have a DiffSuppressFunc")
+	}
+
+	tests := []struct {
+		name     string
+		old      string
+		new      string
+		suppress bool
+	}{
+		{"masked old value suppresses diff", "**********", "realPassword123", true},
+		{"masked old value suppresses any new value", "**********", "", true},
+		{"non-masked values do not suppress", "oldValue", "newValue", false},
+		{"identical values do not suppress", "same", "same", false},
+		{"empty old does not suppress", "", "newValue", false},
+		{"new value is mask does not suppress", "realPassword", "**********", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := valueField.DiffSuppressFunc("custom_properties.0.value", tt.old, tt.new, nil)
+			if got != tt.suppress {
+				t.Errorf("DiffSuppressFunc(%q, %q) = %v, want %v", tt.old, tt.new, got, tt.suppress)
+			}
+		})
+	}
+}
+
+// --- Bug 4: Device group extra field Computed ---
+
+func TestDeviceGroupExtraFieldIsComputed(t *testing.T) {
+	s := DeviceGroupSchema()
+	extra, ok := s["extra"]
+	if !ok {
+		t.Fatal("expected extra field in DeviceGroupSchema")
+	}
+	if !extra.Optional {
+		t.Error("extra field should be Optional")
+	}
+	if !extra.Computed {
+		t.Error("extra field should be Computed")
+	}
+}
+
+// --- Bug 8: custom_properties Computed across resource schemas ---
+
+func TestCustomPropertiesComputedInResourceSchemas(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema map[string]*schema.Schema
+	}{
+		{"DeviceGroupSchema", DeviceGroupSchema()},
+		{"DeviceSchema", DeviceSchema()},
+		{"CollectorSchema", CollectorSchema()},
+		{"CollectorGroupSchema", CollectorGroupSchema()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp, ok := tt.schema["custom_properties"]
+			if !ok {
+				t.Fatalf("expected custom_properties field in %s", tt.name)
+			}
+			if !cp.Optional {
+				t.Errorf("custom_properties in %s should be Optional", tt.name)
+			}
+			if !cp.Computed {
+				t.Errorf("custom_properties in %s should be Computed", tt.name)
+			}
+		})
+	}
+}
+
+// --- Bug 6: escalating_chain nil normalization ---
+
+func TestSetAlertRuleResourceDataNilEscalatingChain(t *testing.T) {
+	s := AlertRuleSchema()
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{
+		"datapoint":              "*",
+		"datasource":            "*",
+		"device_groups":         []interface{}{"*"},
+		"devices":               []interface{}{"*"},
+		"escalating_chain_id":   1,
+		"escalation_interval":   15,
+		"instance":              "*",
+		"name":                  "test",
+		"priority":              100,
+	})
+
+	model := &models.AlertRule{
+		Datapoint:        strPtr("*"),
+		Datasource:       strPtr("*"),
+		EscalatingChain:  nil, // API returns null
+		EscalatingChainID: int32Ptr(1),
+		EscalationInterval: int32Ptr(15),
+		Instance:         strPtr("*"),
+		Name:             strPtr("test"),
+		Priority:         int32Ptr(100),
+	}
+
+	SetAlertRuleResourceData(d, model)
+
+	ec := d.Get("escalating_chain")
+	if ec == nil {
+		t.Error("escalating_chain should be empty map, not nil")
+	}
+	ecMap, ok := ec.(map[string]interface{})
+	if !ok {
+		t.Errorf("escalating_chain should be map[string]interface{}, got %T", ec)
+	}
+	if len(ecMap) != 0 {
+		t.Errorf("escalating_chain should be empty map, got %v", ecMap)
+	}
+}
+
+func TestSetAlertRuleResourceDataNonNilEscalatingChain(t *testing.T) {
+	s := AlertRuleSchema()
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{
+		"datapoint":              "*",
+		"datasource":            "*",
+		"device_groups":         []interface{}{"*"},
+		"devices":               []interface{}{"*"},
+		"escalating_chain_id":   1,
+		"escalation_interval":   15,
+		"instance":              "*",
+		"name":                  "test",
+		"priority":              100,
+	})
+
+	chainData := map[string]interface{}{"key": "value"}
+	model := &models.AlertRule{
+		Datapoint:          strPtr("*"),
+		Datasource:         strPtr("*"),
+		EscalatingChain:    chainData,
+		EscalatingChainID:  int32Ptr(1),
+		EscalationInterval: int32Ptr(15),
+		Instance:           strPtr("*"),
+		Name:               strPtr("test"),
+		Priority:           int32Ptr(100),
+	}
+
+	SetAlertRuleResourceData(d, model)
+
+	ec := d.Get("escalating_chain")
+	if ec == nil {
+		t.Fatal("escalating_chain should not be nil")
+	}
+}
+
+// --- Bug 7: chain stages bounds check ---
+
+func TestSetChainSubResourceDataEmptyStages(t *testing.T) {
+	typeStr := "normal"
+	chain := &models.Chain{
+		Period: nil,
+		Stages: [][]*models.Recipient{}, // empty stages
+		Type:   &typeStr,
+	}
+
+	// Should not panic
+	result := SetChainSubResourceData([]*models.Chain{chain})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	props := *result[0]
+	stages, ok := props["stages"]
+	if !ok {
+		t.Fatal("expected stages key in result")
+	}
+
+	stageSlice, ok := stages.([]*map[string]interface{})
+	if !ok {
+		t.Fatalf("stages should be []*map[string]interface{}, got %T", stages)
+	}
+	if len(stageSlice) != 0 {
+		t.Errorf("stages should be empty for chain with no stages, got %d", len(stageSlice))
+	}
+}
+
+func TestSetChainSubResourceDataNilStages(t *testing.T) {
+	typeStr := "normal"
+	chain := &models.Chain{
+		Period: nil,
+		Stages: nil, // nil stages
+		Type:   &typeStr,
+	}
+
+	// Should not panic
+	result := SetChainSubResourceData([]*models.Chain{chain})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+}
+
+func TestSetChainSubResourceDataWithStages(t *testing.T) {
+	typeStr := "normal"
+	addr := "admin@example.com"
+	method := "email"
+	recipientType := "ADMIN"
+	contact := "admin"
+
+	chain := &models.Chain{
+		Period: nil,
+		Stages: [][]*models.Recipient{
+			{
+				{Addr: addr, Method: &method, Type: &recipientType, Contact: contact},
+			},
+		},
+		Type: &typeStr,
+	}
+
+	result := SetChainSubResourceData([]*models.Chain{chain})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	props := *result[0]
+	stages := props["stages"]
+	stageSlice, ok := stages.([]*map[string]interface{})
+	if !ok {
+		t.Fatalf("stages should be []*map[string]interface{}, got %T", stages)
+	}
+	if len(stageSlice) != 1 {
+		t.Errorf("expected 1 recipient in stages, got %d", len(stageSlice))
+	}
+}
+
+func TestSetChainSubResourceDataNilChain(t *testing.T) {
+	result := SetChainSubResourceData(nil)
+	if result != nil {
+		t.Errorf("expected nil for nil input, got %v", result)
+	}
+
+	result = SetChainSubResourceData([]*models.Chain{nil})
+	if result != nil {
+		t.Errorf("expected nil for slice with nil element, got %v", result)
+	}
+}
+
+// --- Helpers ---
+
+func strPtr(s string) *string    { return &s }
+func int32Ptr(i int32) *int32    { return &i }

--- a/logicmonitor/schemata/name_and_value_schema.go
+++ b/logicmonitor/schemata/name_and_value_schema.go
@@ -13,8 +13,12 @@ func NameAndValueSchema() map[string]*schema.Schema {
 		},
 		
 		"value": {
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
 			Required: true,
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				// LM API masks sensitive property values as "**********"
+				return old == "**********"
+			},
 		},
 		
 	}


### PR DESCRIPTION
## Summary

- Add `DiffSuppressFunc` to `NameAndValue` value field to handle LM API masking sensitive properties as `**********` — eliminates perpetual diff on password/token properties
- Add `Computed: true` to device group `extra` field so API-returned cloud account data does not cause perpetual deletion plans
- Add `Computed: true` to `custom_properties` in `device_group`, `device`, `collector`, and `collector_group` resource schemas so server-injected properties do not cause ordering drift
- Normalize nil `escalating_chain` to empty map in alert rule state to prevent null vs empty map drift on every plan
- Add bounds check on escalation chain stages to prevent index out-of-bounds panic when Stages slice is empty

Fixes #53, #57, #85, #92, #115, #124

## Files Changed

- `logicmonitor/schemata/name_and_value_schema.go` — DiffSuppressFunc on value field
- `logicmonitor/schemata/device_group_schema.go` — Computed on extra + custom_properties
- `logicmonitor/schemata/device_schema.go` — Computed on custom_properties
- `logicmonitor/schemata/collector_schema.go` — Computed on custom_properties
- `logicmonitor/schemata/collector_group_schema.go` — Computed on custom_properties
- `logicmonitor/schemata/alert_rule_schema.go` — nil guard on escalating_chain
- `logicmonitor/schemata/chain_schema.go` — bounds check on Stages
- `logicmonitor/schemata/drift_fixes_test.go` — unit tests (10 tests, 17 cases)

## Testing

- Unit tests: `go test ./logicmonitor/schemata/ -v` (all 17 cases pass)
- Live portal validation: tested against a live LogicMonitor portal (`lmryanmatuszewski`) using Terraform 1.14.8 with dev_overrides
  - Device group 1870: `terraform import` + `terraform plan` = **0 changes** (extra block and custom_properties clean)
  - Alert rule 3: `terraform import` + `terraform plan` = **0 changes** (escalating_chain nil drift resolved)
  - Plan status: `"no_changes"` confirmed via structured JSON output

## Cross-cutting root cause

The provider is auto-generated by go-swagger. The generated schema code lacks:
1. `DiffSuppressFunc` for masked/sensitive values
2. `Computed: true` on server-managed fields
3. Nil-to-empty-map normalization for TypeMap fields
4. Bounds checking on nested slice access

These are common patterns in hand-maintained Terraform providers that the generator does not produce.