### PR TITLE
Escalation Chain and Alert Rule Fix

### DIFF
--- a/logicmonitor/schemata/alert_rule_schema.go
+++ b/logicmonitor/schemata/alert_rule_schema.go
@@ -6,6 +6,12 @@ import (
 	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+func normalizeAlertRuleEscalatingChain(v interface{}) interface{} {
+	if v == nil {
+		return map[string]interface{}{}
+	}
+	return v
+}
 
 func AlertRuleSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -212,7 +218,7 @@ func SetAlertRuleResourceData(d *schema.ResourceData, m *models.AlertRule) {
 	d.Set("datasource", m.Datasource)
 	d.Set("device_groups", m.DeviceGroups)
 	d.Set("devices", m.Devices)
-	d.Set("escalating_chain", m.EscalatingChain)
+	d.Set("escalating_chain", normalizeAlertRuleEscalatingChain(m.EscalatingChain))
 	d.Set("escalating_chain_id", m.EscalatingChainID)
 	d.Set("escalation_interval", m.EscalationInterval)
 	d.Set("id", strconv.Itoa(int(m.ID)))
@@ -234,7 +240,7 @@ func SetAlertRuleSubResourceData(m []*models.AlertRule) (d []*map[string]interfa
 			properties["datasource"] = alertRule.Datasource
 			properties["device_groups"] = alertRule.DeviceGroups
 			properties["devices"] = alertRule.Devices
-			properties["escalating_chain"] = alertRule.EscalatingChain
+			properties["escalating_chain"] = normalizeAlertRuleEscalatingChain(alertRule.EscalatingChain)
 			properties["escalating_chain_id"] = alertRule.EscalatingChainID
 			properties["escalation_interval"] = alertRule.EscalationInterval
 			properties["id"] = alertRule.ID

--- a/logicmonitor/schemata/aws_external_id_schema.go
+++ b/logicmonitor/schemata/aws_external_id_schema.go
@@ -1,8 +1,6 @@
 package schemata
 
 import (
-	"strconv"
-	"time"
 	"terraform-provider-logicmonitor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -25,7 +23,7 @@ func AwsExternalIDSchema() map[string]*schema.Schema {
 func SetAwsExternalIDResourceData(d *schema.ResourceData, m *models.AwsExternalID) {
 	d.Set("created_at", m.CreatedAt)
 	d.Set("external_id", m.ExternalID)
-	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+	d.SetId(m.ExternalID)
 }
 
 func SetAwsExternalIDSubResourceData(m []*models.AwsExternalID) (d []*map[string]interface{}) {

--- a/logicmonitor/schemata/chain_schema.go
+++ b/logicmonitor/schemata/chain_schema.go
@@ -40,12 +40,43 @@ func SetChainSubResourceData(m []*models.Chain) (d []*map[string]interface{}) {
 		if chain != nil {
 			properties := make(map[string]interface{})
 			properties["period"] = SetPeriodSubResourceData([]*models.Period{chain.Period})
-            properties["stages"] = SetRecipientSubResourceData(chain.Stages[0])
+			properties["stages"] = setChainStagesSubResourceData(chain.Stages)
 			properties["type"] = chain.Type
 			d = append(d, &properties)
 		}
 	}
 	return
+}
+func setChainStagesSubResourceData(stages [][]*models.Recipient) []interface{} {
+	if len(stages) == 0 {
+		return []interface{}{}
+	}
+
+	result := make([]interface{}, 0, len(stages))
+	for _, stage := range stages {
+		if len(stage) == 0 {
+			result = append(result, []interface{}{})
+			continue
+		}
+
+		serializedStage := make([]interface{}, 0, len(stage))
+		for _, recipient := range stage {
+			if recipient == nil {
+				continue
+			}
+
+			serializedStage = append(serializedStage, map[string]interface{}{
+				"addr":    recipient.Addr,
+				"contact": recipient.Contact,
+				"method":  recipient.Method,
+				"type":    recipient.Type,
+			})
+		}
+
+		result = append(result, serializedStage)
+	}
+
+	return result
 }
 
 func ChainModel(d map[string]interface{}) *models.Chain {


### PR DESCRIPTION
API-returned ExternalID UUID used as the dataresource ID instead of time.Now().Unix()
Alert Rule and escalation chain issues fix